### PR TITLE
feat: Offline + localstorage + geolocation finishing touches + error handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
     "@typescript-eslint/no-use-before-define": 2,
     "no-unused-vars": 0,
     "@typescript-eslint/no-unused-vars": 2,
-    "typedefs": 0
+    "typedefs": 0,
+    "react/require-default-props": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
+    "react-lottie": "^1.2.3",
     "reactjs-localstorage": "^1.0.1"
   },
   "devDependencies": {

--- a/src/components/mainMap.tsx
+++ b/src/components/mainMap.tsx
@@ -52,11 +52,11 @@ const getCurrentLocation = async ({ setLatLng, setLocated, latLng }) => {
   let pos = null;
 
   // we have a previous location, but we're offline
-  if (!navigator?.onLine && latLng) {
+  if (navigator && !navigator?.onLine && latLng) {
     pos = latLng;
   }
 
-  if (navigator?.geolocation?.getCurrentPosition) {
+  if (navigator && navigator?.geolocation?.getCurrentPosition) {
     navigator.geolocation.getCurrentPosition(
       (position) => {
         pos = {
@@ -184,7 +184,7 @@ const MainMap = ({ classes }: { classes: object }) => {
       />
     );
   }
-  if (!navigator?.onLine) {
+  if (navigator && !navigator?.onLine) {
     return (
       <MapLoadingSkeleton
         classes={classes}
@@ -203,6 +203,7 @@ const MainMap = ({ classes }: { classes: object }) => {
       // For users who have denied location access (located === false), show the
       // map without geolocation map center assumption – defaults to Taos, NM
       && (located === true || located === false)
+      && navigator
       && navigator?.onLine ? (
           renderMap()
         ) : (

--- a/src/components/mainMap.tsx
+++ b/src/components/mainMap.tsx
@@ -52,11 +52,11 @@ const getCurrentLocation = async ({ setLatLng, setLocated, latLng }) => {
   let pos = null;
 
   // we have a previous location, but we're offline
-  if (!navigator.onLine && latLng) {
+  if (!navigator?.onLine && latLng) {
     pos = latLng;
   }
 
-  if (navigator.geolocation) {
+  if (navigator?.geolocation?.getCurrentPosition) {
     navigator.geolocation.getCurrentPosition(
       (position) => {
         pos = {

--- a/src/components/mainMap.tsx
+++ b/src/components/mainMap.tsx
@@ -1,6 +1,9 @@
 import { useContext, useCallback, useEffect } from 'react';
 import { useJsApiLoader, GoogleMap } from '@react-google-maps/api';
+import Lottie from 'react-lottie';
+import { Typography } from '@material-ui/core';
 import { StoreContext } from '../context/store';
+import animationData from '../lotties/map-loading.json';
 
 const DEFAULT_ZOOM: number = 12;
 
@@ -17,8 +20,47 @@ const libraries = ['places'];
 // eslint-disable-next-line no-underscore-dangle
 let __map;
 
-const getCurrentLocation = async ({ setLatLng, setLocated }) => {
+const MapLoadingSkeleton = ({
+  classes,
+  text,
+}: {
+  classes: object;
+  text?: string;
+}) => {
+  const defaultOptions = {
+    loop: true,
+    autoplay: true,
+    animationData,
+    rendererSettings: {
+      preserveAspectRatio: 'xMidYMid slice',
+    },
+  };
+
+  return (
+    <div className={classes.map}>
+      {text ? (
+        <Typography className={classes.mapLabel} variant="h4" component="h3">
+          {text}
+        </Typography>
+      ) : null}
+      <Lottie options={defaultOptions} height={400} width={400} />
+    </div>
+  );
+};
+
+const getCurrentLocation = async ({
+  setLatLng,
+  setLocated,
+  located,
+  latLng,
+}) => {
   let pos = null;
+
+  // we have a previous location, but we're offline
+  if (!navigator.onLine && (located || latLng)) {
+    pos = located || latLng;
+  }
+
   if (navigator.geolocation) {
     navigator.geolocation.getCurrentPosition(
       (position) => {
@@ -27,22 +69,36 @@ const getCurrentLocation = async ({ setLatLng, setLocated }) => {
           lng: position.coords.longitude,
         };
 
-        setLatLng(pos);
-        setLocated(pos);
-        __map?.setCenter(pos);
+        if (
+          typeof position?.coords?.latitude === 'number'
+          && typeof position?.coords?.longitude === 'number'
+        ) {
+          setLatLng(pos);
+          setLocated(pos);
+        }
+
+        if (__map?.setCenter) {
+          __map.setCenter(pos);
+        }
       },
       () => {
-        setLocated(pos);
+        // user has likely denied location accessp
+        setLocated(undefined);
       },
     );
   } else {
     // Browser doesn't support Geolocation
     setLocated(pos);
   }
+
   return pos;
 };
 
-const MainMap = () => {
+interface IMainMap {
+  classes: object;
+}
+
+const MainMap = ({ classes }: IMainMap) => {
   const {
     setLatLng,
     latLng,
@@ -50,6 +106,7 @@ const MainMap = () => {
     setGoogleService,
     located,
     setLocated,
+    setSidebarError,
   } = useContext(StoreContext);
   const { isLoaded, loadError } = useJsApiLoader({
     googleMapsApiKey: process.env.GATSBY_GOOGLE_API_KEY,
@@ -57,6 +114,9 @@ const MainMap = () => {
   });
 
   const onLoad = useCallback((mapInstance) => {
+    // prevent errors for offline app context
+    if (!window?.google?.maps) return;
+
     __map = new window.google.maps.Map(document.getElementById('map'), {
       center: located || latLng,
       zoom: DEFAULT_ZOOM,
@@ -74,19 +134,35 @@ const MainMap = () => {
     service.nearbySearch(
       request,
       (res) => {
-        setPlaces(res);
+        // don't overwrite potentially useful previous results in local storage unless
+        // we have a meaningful response from the places service
+        if (res.length > 0) {
+          setPlaces(res);
+        }
       },
       (err) => {
         // TODO: handle for error
-        // eslint-disable-next-line
+        // eslint-disable-next-line no-console
         console.log('~err', err);
+        setSidebarError(
+          `Received the following error fetching nearby places. Error: ${err}`,
+        );
       },
     );
   });
 
   // Request user location
   useEffect(() => {
-    getCurrentLocation({ setLatLng, setLocated }).then((__located) => {
+    getCurrentLocation({
+      setLatLng,
+      setLocated,
+      located,
+      latLng,
+    }).then((__located) => {
+      // don't trigger onload map callback if user is offline in which
+      // case window?.google?.maps is always falsy - would be cool if
+      // Google api worked offline but that would decrease their leverage
+      // 😅 https://www.quora.com/Why-does-not-Google-release-an-API-to-support-Google-Maps-in-offline-mode-for-mobile-apps
       if (__located !== null && window?.google?.maps) {
         onLoad(__map);
       }
@@ -103,16 +179,49 @@ const MainMap = () => {
       }}
       mapContainerStyle={MAP_CONTAINER_STYLE}
       options={{
-        center: latLng,
+        center: located || latLng,
         zoom: DEFAULT_ZOOM,
       }}
       onLoad={onLoad}
     />
   );
 
-  if (loadError) return <>Map can't be loaded right now</>;
-  // TODO: loading skeleton
-  return <>{isLoaded && located !== undefined ? renderMap() : null}</>;
+  if (loadError) {
+    return (
+      <MapLoadingSkeleton
+        classes={classes}
+        text={"Map can't be loaded right now"}
+      />
+    );
+  }
+  if (!navigator?.onLine) {
+    return (
+      <MapLoadingSkeleton
+        classes={classes}
+        text={"You appear to be offline, we can't locate you"}
+      />
+    );
+  }
+
+  if (!isLoaded) {
+    return <MapLoadingSkeleton classes={classes} text="Locating you..." />;
+  }
+
+  // For users who have denied location access, show the map without
+  // geolocation map center assumption – defaults to Taos, NM
+  if (navigator?.onLine && !located && isLoaded) {
+    return renderMap();
+  }
+
+  return (
+    <>
+      {isLoaded && located !== undefined && navigator?.onLine ? (
+        renderMap()
+      ) : (
+        <MapLoadingSkeleton classes={classes} text="Something went wrong..." />
+      )}
+    </>
+  );
 };
 
 export default MainMap;

--- a/src/components/mainMap.tsx
+++ b/src/components/mainMap.tsx
@@ -20,6 +20,9 @@ const libraries = ['places'];
 // eslint-disable-next-line no-underscore-dangle
 let __map;
 
+// NOTE: only necessary because gatsby build compiles server side via Node
+const isBrowser = () => typeof window !== 'undefined';
+
 const MapLoadingSkeleton = ({
   classes,
   text,
@@ -52,11 +55,11 @@ const getCurrentLocation = async ({ setLatLng, setLocated, latLng }) => {
   let pos = null;
 
   // we have a previous location, but we're offline
-  if (navigator && !navigator?.onLine && latLng) {
+  if (isBrowser() && !navigator?.onLine && latLng) {
     pos = latLng;
   }
 
-  if (navigator && navigator?.geolocation?.getCurrentPosition) {
+  if (isBrowser() && navigator?.geolocation?.getCurrentPosition) {
     navigator.geolocation.getCurrentPosition(
       (position) => {
         pos = {
@@ -184,7 +187,7 @@ const MainMap = ({ classes }: { classes: object }) => {
       />
     );
   }
-  if (navigator && !navigator?.onLine) {
+  if (isBrowser() && !navigator?.onLine) {
     return (
       <MapLoadingSkeleton
         classes={classes}
@@ -203,7 +206,7 @@ const MainMap = ({ classes }: { classes: object }) => {
       // For users who have denied location access (located === false), show the
       // map without geolocation map center assumption – defaults to Taos, NM
       && (located === true || located === false)
-      && navigator
+      && isBrowser()
       && navigator?.onLine ? (
           renderMap()
         ) : (

--- a/src/components/resultsSidebar.tsx
+++ b/src/components/resultsSidebar.tsx
@@ -12,17 +12,62 @@ const useStyles = makeStyles((theme) => ({
     height: 'calc(100vh - 5.5rem)',
     width: '35vw',
     background: '#f2f2f2',
-    [theme.breakpoints.down('md')]: {},
+    [theme.breakpoints.down('md')]: {
+      // TODO: decide about drawer vs other hide / show for final mobile
+      // for now, we hide it
+
+      display: 'none',
+      // width: '100%',
+      // height: 'auto',
+      // position: 'relative',
+    },
   },
   card: {
     margin: '1vw',
     width: '33vw',
+    [theme.breakpoints.down('md')]: {
+      width: '96vw',
+      margin: '2vw',
+    },
+  },
+  sidebarMessage: {
+    textAlign: 'center',
+    padding: '3vw',
   },
 }));
 
 const ResultsSidebar = () => {
   const classes = useStyles();
-  const { places } = useContext(StoreContext);
+  const { places, sidebarError } = useContext(StoreContext);
+
+  if (sidebarError) {
+    return (
+      <Box className={classes.container}>
+        <Typography
+          className={classes.sidebarMessage}
+          variant="h5"
+          component="h3"
+        >
+          {sidebarError}
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (places?.length <= 0) {
+    return (
+      <Box className={classes.container}>
+        <Typography
+          className={classes.sidebarMessage}
+          variant="h5"
+          component="h3"
+        >
+          Searching for nearby restaurants...
+        </Typography>
+      </Box>
+    );
+  }
+
   return (
     <Box className={classes.container}>
       {places

--- a/src/context/store.tsx
+++ b/src/context/store.tsx
@@ -44,8 +44,10 @@ const StoreProvider = ({ children }: { children: ReactChildren }) => {
   };
 
   const setLocated = (val) => {
-    reactLocalStorage.setObject('at_lunch_last_located', val);
-    _setLocated(val);
+    if (val?.lat && val.lng) {
+      reactLocalStorage.setObject('at_lunch_last_located', val);
+      _setLocated(val);
+    }
   };
 
   const setLatLng = (val) => {

--- a/src/context/store.tsx
+++ b/src/context/store.tsx
@@ -14,6 +14,10 @@ const defaultState = {
   googleService: () => {},
 };
 
+const isEmptyObject = (obj: any) => obj
+  && Object.keys(obj).length === 0
+  && Object.getPrototypeOf(obj) === Object.prototype;
+
 const StoreContext = createContext(defaultState);
 
 const StoreProvider = ({ children }: { children: ReactChildren }) => {
@@ -44,10 +48,8 @@ const StoreProvider = ({ children }: { children: ReactChildren }) => {
   };
 
   const setLocated = (val) => {
-    if (val?.lat && val.lng) {
-      reactLocalStorage.setObject('at_lunch_last_located', val);
-      _setLocated(val);
-    }
+    reactLocalStorage.setObject('at_lunch_located', val);
+    _setLocated(val);
   };
 
   const setLatLng = (val) => {
@@ -58,15 +60,18 @@ const StoreProvider = ({ children }: { children: ReactChildren }) => {
   };
 
   useEffect(() => {
-    ['at_lunch_places', 'at_lunch_last_located', 'at_lunch_lat_lng'].forEach(
+    ['at_lunch_places', 'at_lunch_located', 'at_lunch_lat_lng'].forEach(
       (key: string) => {
         const storedValue = reactLocalStorage.getObject(key);
-
+        // NOTE: localstorage returns empty object for previously stored values
+        if (isEmptyObject(storedValue)) {
+          return;
+        }
         switch (key) {
           case 'at_lunch_places':
             setPlaces(storedValue);
             break;
-          case 'at_lunch_last_located':
+          case 'at_lunch_located':
             setLocated(storedValue);
             break;
           case 'at_lunch_lat_lng':

--- a/src/lotties/map-loading.json
+++ b/src/lotties/map-loading.json
@@ -1,0 +1,1154 @@
+{
+  "attribution": "Brahmdeep Singh - https://lottiefiles.com/73383-street-view-map-loader",
+  "v": "4.8.0",
+  "meta": { "g": "LottieFiles AE ", "a": "", "k": "", "d": "", "tc": "" },
+  "fr": 60,
+  "ip": 110,
+  "op": 371,
+  "w": 1080,
+  "h": 1080,
+  "nm": "Map Loader",
+  "ddd": 0,
+  "assets": [
+    {
+      "id": "image_0",
+      "w": 317,
+      "h": 451,
+      "u": "",
+      "p": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAT0AAAHDCAYAAABWA830AAAACXBIWXMAAAABAAAAAQBPJcTWAAAAJHpUWHRDcmVhdG9yAAAImXNMyU9KVXBMK0ktUnBNS0tNLikGAEF6Bs5qehXFAAAgAElEQVR4nO2d25ccV5Xmv5OZVbJuVsmyZS6yVTYYZEqgUgN2m5tLzXSv6TWzGjE9Pa8Uf8HoPxjxPmuNmYd5mHmgvBbzMKyeQfDCwpipkukG3OB2aZDa5mJcMgZjG11KknWryjzzkLfIyBOZcTknYu8d+7eWwJWXiP2dy5cn4ouMNFCUHNjVxTlsby92/7DzsGY+8uwiDOY87GYD1mwM/2yvo9G8CgDmL8+vedi+UkNM1QUoNBmY2sDQBkY2D+BwpcWNchHABvoGaewGjNlAq7VuTqxfrbg2hSBqejXHri7O4fb2IoxdhMEiDOYBPF11XYXpjuxNAOswWIfFBmDWdYWoqOnVDPu9o0toYKm3cluExWFRoyCNFoNz6PTMUI2wdkga7koMu7o4h7t3lmAbSzBYAnBs8KSknvej5Sxg1mDa62juWNNDY7lIGvoKAPv9x086TQ6Q1duhtRicgzVnAKzpSlAWkqZBLbHfOzIP0zwJg5NIOhcnpZer07EJYA0WZ9Bur5m/fnWjskqUwkiZDrXCPrewiA6W0cBJ2IQkVUrPUtRhcA4WK9hun1ED5AfFIaU4qJXRAXy0qAGyg8vQqiX2e0fm0Wgtw9hlNTqijNZ8DgYraMysaBBCF47DTDR2dXEOW1snYbGMSdfLSek5rjqm1/0doLNi/tUrZ0qoRskA1yEnDvvcwiIsTgE4CWCf80VSeourjnx1X4Q1K2htr5gTevhLAa7DTwz2uYXlias6ST3EUYvfmr8Da57RS2CqheMwZE/3ouHtU4nn6iT1Ckct4Wu+CIPTaMyc0XN/5cNxSLKlG0w0TyPpEFZKb3DVUX7dm7DmGbRaz6j5lQfX4cmKiNl9ZexJKT3AVQeNujcBnEGzfVrP+4WHRpcLJdHsJLU6Ry20a35WzS8stLufKU6zk9TSHLXwq1nNLxD8hgJhxsxOUuty1cKx7pGazdfQ0HN+PuE4JMhhVxfncGfrNAz+IwA5rcpVB8e6J9e8CZhn1Pz8wHF4kMJ+/+hpwJ6CSbigmCMcRwXHmoGsdV8EcNp88cJKkFpqAtehUjn2+4+fhGk8A1q/F5EfjiOBY82Aj7rPomNO60XO+eA6bCrDfu/IPJrNFcj5HQl+cKw7RM0Gz8LMnNJD3mw0qi6AE/b7R0+j2XwdnA3PRP5xgmPdoWu2+Ao6Wxv2hwunAu1BJJyGUGXYHxxdgrUr4Hooy7WXte4snEUDp8yJC+uV7J0RXIdVKfRu83Qa6KWy3ODYuxxrBgjVbb5mvnj+dNVVUIZMV1GDbVDBtUc51k235nNoYFlXfW7odltFsFzdce1FjnWzqllXfS5YdWFoWJ2749pzWnfZ6Kovhqa3Pez3j56GtaugbnjcEkyAZ/IK8K17lGOwWNOEdwjv7vRA77q7M4j/MDYlOPYSx5oBvnW7GNfyHZiZ5bpf1yepizPTCytWkPSbFFXCtWc41s2x5iSma7kIg5N1Ptyt7eGtfW7hGZjGt0HJ8LgeTnGsm2PNSWTTchgWL9f5cFdCl2eC5OEsx17gWDPAt+44fnTU8nBXyhBIRS+dPQMKqzuOLc+xZoBv3S78azkHU690tzaHt92fWrSrqNLwuB5Sca6ZW90uwmrpprurj58MsnWC1ML07HMLKwC+UcnOuU4+jnVzrDmJcrXsg218uy7n+SQMj0R6365YQxXn7zi2LMeaAb51x6Gh41nzFxeWqy4iJDSaOQD2uYVFACso0/A4tibHmgG+dcehqeMczMyS1ICDZpMXpGd4ayjj/B3XFuRYN8eak6Cv5RxM+6TEX2MTd07PPrewjNCGx/XcEce6OdacBC8tx2Cb63Z1YbHqQnzDo/lT0jO8cIEFx9biWDPAt+44XHUM694EsCTpkhYxK71ghsfr07kLx5oBvnXH4arDXfc+AC/b1YXlCioKggjTs88tPAOfhsd90HKCa1u74Kgjfft/Q4rxceuiMXrX4H2l8Ia4tgTHujnWnARHLcVq/qo5wft3dzl22YDChsdVvdZdLVx1+KubtfFx7b5ihsdRNceaAb51x+GqI1zdbI2PZVfmMjyOSjnWDPCt2wVHLeXVzNL42HVpJsNjp64Hx7o51pwERy3V1czO+Filt72UdrLhcU0DOdbNseYkuGqpvmZ2qS6bLp56HR4bJRE41gzwrTsOVx0062az4qPZfDESDY9F9TE41gzwrdsFRy30a2bzzQ3yTTlmeOQrToBj3RxrToKjFn41szA+0s06uFuKIXB79zyQbt0EONacBFctXOvusgm0FynfnYVskGGfW1iEYWh4ekK8Wri3P7e64xjsg2mesauLc1WXkgRJ07Ori3NoYAUUfsAnDVwHLNe6XXDUIbf9j6Gxdaa6YiZD0vTQ3lqDJfQTjUlwHLASJxonLRxrTmKSFoun7erCSrkFpYOc6dnnFlZIGx7HQcux5iS4auFYs4ss7W/wFbtK78eGSHWDfW5hGaaiXy2bBKlWygDXuuNw1cG17jhFdVhzwpw4v+ajFB+Q6Rb7g6NLgF2tuo4BZFomI1zrjsNVB9e6XfjTsglLJ9El0UX2e0fm0Wqug0JwQaJFMsKx5iQ4auFYcxLhtJyDpfELazTO6c00z6BKw+N4nohjzUlw1MKx5iTK0XIM2Hom6B5SUrnp2ecXnqkkuOA6aDnW7ELbv1qqaH8iwUal3Weff/wkbOPbpe2Q62DlWnccrjq41u2CghaL41V+Va2yJij1PB6Fjs4Kx5qT4KiFY81J0NNyEXZmsarze9Ud3oY+j8fx8IljzUlw1MKx5iRoazlc5fm9SkzP/uDo6SDn8Wh3dDIca3ah7V8tnNq/e35vuZpdl4z36/E4dLALrnXH4aqDa91xuOro1r2JTvnX75W60uveecGuFN4Qp0+0KFzrdsFRh7Z/tYy3/z40mitll1Hu4W176zSAw7nfL6Oj+cJRC8eak+CoZXrNT9sXyr2MpbTmy315CqcO7sOx5iS4auFadxyuOrLW3SnvMpZSVnp2dXEOtpE+reH4iQbwrNkF9/bnVnccrjqK1N1AaWluOYe3aQ5r69jR1OCoQ9u/Wvy1f2mHucGbeGpay62TAZ41J8FRC8eak+CoJVzNpaS5Jaz0HGktx09njjUnwVULx5pdaPsnUUqaG9T07A+Onkb/sFY7ulq4tz+3uuNw1VF+3U/bFx4/GXIHwaTY7x2Zx0zz9VDbDwq3gZkEVx1c63bBUUvVNRtcRDvcd3PDrfRmy7/osBBcP4ldcNQhsf05aaFUs8VhNLaDhRpBJNrnHz8JlHjLqLxQ6GBfcNTCseYkuGqhXHen/UiIUCPQSi/DNXlVQOUTrSiUPp2zwLFmF9zbn3rdgUIN76Y3El5QgktHT4OrDq51u+Cog2f7P21Xjy753qhX07Ori3MwtvLbQQ/g2dFuOOqQ2P6ctHCsOU7Tww1KYvhd6XW/eVHtL5pJ6Og+HLVwrDkJrlo41uyiq+GwfcHvffe8NY1dPTKPdoWXqEjoZICvDq51x+Gqg2vdcdw6NtGemfd1CYu/lV67edrbttLC9ZM4DlcdXOt2wVFHfdp/n89LWLw0V6mrPAkd3IejFo41J8FRC8eak8imxdtqz89KL/QqT+InGictHGtOgqsWjjW7yN/+3lZ7hZsx2CpPQgf34arFY923txro2OQNzjQtZpodfzuMou1fLf50eFnttQqX4XuVpx1dLTnrvnm3id9d2YnX3tmDKzdncPXWLK7fbuH67RZMbJvG9HdjI/893PeB3Xewo2VxcO9tzO3cwvvnbuOh/Texa7YdXEflcK3bhX8t/dXe6SIbKVSWt1WednS15Kj50o0d+OXbe/DbP+3CG5d34/rt7udn3+CipjayqymGNzjyGdkOYIzFfbvu4sCeuzh833t47OB7OLDnjhctlcOx5iTCaym82iu20iuyytOOrpYcNf/u8i68+Pp+/PKdvbh2a6a7GWMjxhTdtF/DMwCu3JzFlZuz+M27e/B/fwns33UXj95/Ax/74HU8tP9mdkFVwnHMJFGulsKrvdzl5lrlaUdXT8a6L93YgdVf3o9X3753sJobbKpEw4vWb3qPRzexe8c2PnFoE0c/cM29AqQC13ETp1odhVZ7+Vd6WVZ52tHVkqPuH792AD/b2I83r+zsmtSYidExPGOAm3db+OlvD+DF1+/DI/e/h2OHNvGRB69nFx4CruPGBQ0t+9DcOglgJc+bc0mwq4tzaG9tYNJXzmg0jh84aslZ849fO4DnXzmIa7dnYPomRdzwonVFn7t/zx187APX8OQjl6cL9w3HMZMETS0XzRcuzOd5Yz7T+8HR0zD2P/nZGlE4ailQc9/sNm/N9MyJt+FFn9s5s42//Ng74Vd+HMdMEiy0dL5svvDKmazvymd6zy9sIPrbF1LgqqVA3a/+cQ/+188figQTFRpef98xbUUMr/tYt4YDu+/ii4+/jUP7b7kbIy9cx00cfjrOmi9cWMr6pswy7Q8XlmHxDYYN5IarjoJ1X7qxA3//zx/Ar97eO9ykYMOL6vvwwRv4iyPvZLvuLw7XcROHu44mjpvPXljP8pY8QcYy+4biWr+nup9/5SB++OpB3N0efguxLoYHAL95Zw8uXtqNzz/2Lj5xaBOp4TpuXEjR0sYpAMtZ3pJJul1dWEQHL2d5Dyk4drTHmi/d2IFvvvgQLl7eNbLZUg0valq9/ynT8BB77YP33sLfHHsredXHccwkIVGLwSa2sl2+ku2GAxZ07oqcFhP5x4UANb/8xhz+8w8eU8OLvfad6zvxzRcfxptXdsY3wmvMJMFx/Cfh0mIHl69k2kwq7OriHDpTLlOhAtcODlT3t146hJ/+9r6xXdTd8KLPGwM88cglPPHIFbCH6/h3kU7LOfP5C4tpN5l+pdfZOgnKhsf1Ey1g3TfvNvHM8x9Ww3O9tv+8GWr42esH8O2XPwi2cBz/LrLPiWP2HxcCmF7Gk4WlwbGjSzDoSzd24L/+8EN448quwS4Hu/dteIax4QEjtfzh6k78z58+jJt3m2AB1w97F0V0tNOfeku1C7t6ZB6dCn//Ig7HDi6x5jcu78J/O/voIJ0NbnjRfTA2PETaZvfsNv79p94sdllLKDiO/yR8aTHYNJ+7MJfmpelWep3WcpF6vMD1E63kmtXwihseALx3t4W///khOis+ruPfRQgtFvvsC4+nCjRSHt7a5QLl5IdrR1dUt3fDM0wNz6kxveH193dzq4X/XbXxcRz/LsqYE43GctpSJlLJtXkcO7nimoMYHuKvZWJ4zrqzGd5Qk8Xu2W38u0/+vrxDXY7j30UVOrZn9k+7Zm/6Sq9TUoDBcVVHpOZLN3bU0/BMeMMz6N626v+89MGwKz4iY8kLVepIcc1emsPbTBf+ZYJrRxOq+ebdJv7Hjw7nN7zIc+wMD+ENr//Era0Wvrv+AXiF6/h3QUVLY7pfTTQ9u7qwiP7dVHxBpXGyQrTu//7CI3jnxj0Achpe/zGAvuGZagyvX/eNOy1895wH4yM4jnJBcU5YfMmuLk5McSev9Hwe2lJrnDRQ7NQI33rpUP7r8DgaXnRbJRten3eu7cDPN/YjM8THUmo46JhyiDvt8LbYoS2HBorDpOaX35jL/00LyoaXou6qDK//0v/35tz4d3VdMBlLqeCkY8ohbqLp2dUj88hzaMu1oxnVfOnGDnzrpUMAEgyvwdjwxmqhZXj996+9+oA72OA6/l1w1NKtdWnSS5JXep1m+lUex8YB2Nb9zRcfwp3txugkjRpe7PVqeH4NzxiLrU4DP/rV/bEXgD9M50Ss5okXKk86vJ1setwbh1vdPZ5/5eDw9lA9HX1DUMMrx/D6vHVtJ3797h62Y2kA1zkxqe5mYynpbZNM7+mJO+IE106NcenGDvzw1YOxScvA8Iw8w+vX/U+v3Ufnq2pZ4Tgn0s5lm7xoc5qefT62NORoGhxrTqKn45svPtS9Ho+b4cXqSnrOVTcJwzPJdW/bBv7h1/eDDRznRb6aD9ufHJl3PeFe6ZnGEsvGAXjW7CLW/i+/MYc3Lu9Swxt5f0DDMxHDQ0Ldvf/44+Y9uHRjFmSp61zuNJdcDyeY3uT0gxxcO9VFgo7vrr9fDW/k/YENL7ItZ92x7a398iBIwXVO+Kw74RB3zPR6VzMf87DLsHDtVBdTtPz4tQO4dmcm8lIChhepue6GBwPcutvEr9/Zg8rhOCfCzeUl14OOld4d5wtJUCOji/L8vxyMvKViw4vVzNbwjD/D67fBL35X0a8pcJwX5dS8z3Ub+XHT6zSWgpaRB24dmkSOjv7xaweweXuGjuHF5XAyvN4bR+7MEq8vp+EBwK2tJn5T1mqPo9EB5ddsx1d746ZH5Xwe1051UUDH8/9ysDrD65sEd8OLvCmU4fVf8os3A672uM6JautOsdKr8nwe10514UHLj187gGu3Z6ozPAgxvPi2xrY/3Jaz7pSGBwPc3mqm+15uWrjOCTp1L8UfGDE9u3p07AXBodM4xfGs5Wcb+9XwshhedEVXgeH129HLao/jnKA5lw/HbzU1utLrlHhoS69x8hGoo9+4tAtvXt6phpfF8AZPV2d4AHDt9ky+b2nQNI3JcKi5ORrOjpqesal/MDcXHBooDSXo+KfX9/s3vFjdanj+DQ+wgAVefWsvUsF1TnCq2TRHfC1+Ts+/6XHtVBcl6jj3+zn/hhd9PvYYG8MztA2v//fGn3YjEa5zgmvdDbs08mf/P3rHvX5uDc+1cVxUoOXlN+YGv3kxKKOuhhdpfxPTStXwAGC708Cl92JfTeM4JyTMZYukld528VUe98bpU3FHn//DvSN/pzY8I8jwYu3PyfD6/OrtvZWPpVxwrDmJro590TBjaHp5QwwpDURIxxuXdw3+O5XhmeHzYgzPta1Y3a7aSRhe78PncnylRx0i478wrrncGi7qhqZn7HyhjXKFmI7fXdmFa7d637NNa3hgbnhGiOFFPnwAi1sc7rNXl7ncGC7qoieO5lNtUFLjENTy67e7J8BFG17fHMxweyIMb/B/drCP1yjchCAO4fGfmbRaIou6qOnJuVOyCyYd/dt398g3vNi+WBqemW54MMDvr94DEjAZ/6nIo8UOF3UtoJfc2q3RjUqAoY7fXdkpx/BGzCBWN3fDc2iKGx4AXLtV8Xk9hnPASXEdg0Vdb6W3vSjyk4ATBrj03o7B7eBZG54RZHjRFV1GwzPA2KVHpSBlLnvW0U9wez2SIcSgCseOjtX8xuWdMgxvtFx+htdr4FG92Q2vv5/f+7wBQRIcx38SoXT0Etye6Zn5ALsID9eOTqj5rav3qOHF6nbVHszwIqs6X4YHA1ztpfHe4Tr+XZShpdkeWemF/c6tT7h2dIq637p2z+ClZA1vsAoSYHgmZnjOtihmeABw2fePBnEc/y7Knsu2+x3cVu/PuQkvpQHHTs5Y8+2tJl3DixtR7zF2hjeykgtveAbdfi0Mx/HvolIddg4Ymt58dYVMgGNHF6j50o1ZNbzofgQYHgxwt50zzOA4/pOgoWVkpefnRgM+oNE42fFQ953thhqeo3bOhmdgYTtID9fx74KollY3xt2a/sqQEG2cqXisu90x1RleknFwNLwx3dUangHQSTNQuM6BOLR1PA0ALS93V8kD7cZJJlDdd/rXc6nhxWpJYXgmYV8EDG/ieOE6B+Iw09Ga/hLPMGsgAOXVrIYXq2WK4Y3sN66bjuGNlMZx/CfBUIv9yZH5VikXJjNsnKpqVsMTaHgGaFuDZmNUE0s4zuUo2635BmDmg2zcRP5xosKavRqeEWZ4JlI3F8Mb1FzR19F8wXUuu2j5Przl2ihE6vZqeBMSTRaG5zA2doYX2RY7iMwJL8S0+DE9jg1EsWY1vFgtjAzP2T/DbbGBU62TSNLRwVIr91fQODYO8ZozGV7MUPrPqeGVZHgJHzxJhrdztg2yEJ8XqUmpo4UsX0Hj2jhM6q6d4fX3JdzwSEK5tqxk1DL98JZr43Ctu4dIw4t9xY6N4cVvOxXb9+jjw2252qBSqNThgwJakk2PYwNxrLnHjtbwu0pqeAQML1oHxh/LYniVDkvGc2IMT1pGTY9jA3Gs2UH/Gq74JFHDk2B4FaS3QuaFdx3GLrXQAMtEXWKn7mh1sBW5Iwc7wxsxAEftVA3PaWL+DK9R1liVMieAoFp4XTFpIv84k6DjwJ67w5eo4YU1PFOO4QHATDPLbVYyImVOAKVpKf+7t1mR0Jl9pmjZMdO9rEENL6Dhmd5zsX2EPKS9Z8bz5So1mhMhaMASvGtyTT+9Hrz3thqea19FDC/S9lUYnjHA3G5Pt26r4ZwIQQvAfDW7diChQ4HcOt6/70737ZQMz4zLYWF4Yybdey62j9CGZ9D9MMtNzedECBowWK+0AimrOg86Ds3dUsOLbi+r4TnO0/VfU5XhwYyeq02FlDkBkNRRTZChnerkwN47mI2d9FbDm2J4g7GU8L3lig0v9dCQOCeIainP9Ig3RCYCannfvuGhUHDDi2hgZXgmYngAXKaGwd/VGt6ee6acz9M5UTrhTY9JQ0ylpE59+L6b3d2FNDwTfy0zwxt5H13DM7B48N47GIORQUyEqY4wpse0McaoQMeHDr4X3vAQfa0aXnzfo4/3tpXD8ADgQwdvRAQPNsgb3jqu+jM97VQvPHTfTeyeHR4SqeHxNbxG08qbE9y1WLNezPSkNARASssjD0QPcXukNTyD4eTjZnhGiOH1tGRObalBaE4Upq+jkefwVmJDENNy/OGr+Q0PzAzPxIyaq+GZXpua4XMffd91sIPonMhFgpYGOtjItAHuMOjU7iHudvcP6YYX31bkb/KG1zdrVx8ZS/tuyXGIz4nUpJjfDcBsFNkAG5jpOHz/TbfhxXSo4bmfC2Z4g1Vd9PnxfbA4tJUyv7PosNYRZEhpCIC1ls9+6NKoERjHhOdgeK66ORpef1UXfU+C4VlL+NCW8ZwYI48O0w8yJDYEcy0H9t7B/XvvOAygC1nDi53XmrQv8oZnABj3ijXJ8ABgpkns0FbInADgRUsDzXa13731gdBOXfjgNX6GF6mDpeGZiOFFtzOiM9nwjLH4+ENXQQKBc8IHDbSbRHooI0KNLsqTj17Grpnt2EsJGZ6BPMOL7CMiP7Xh2Y6p9nyelHkRSsftVsHr9KpAQocCqTv1U49eibyFmOFFXu963LUvMoZngP5dWUZ0FjA8AHj04HsoHSlGBwTXYU6sX22YE+fXwu3CEzXu1CcfvYydM9vVGp4RaHhw6ew+Hnk4k+FZa/Bo/2tnoZE4J8Jr2QQo/0aGduqATz9ypVrDG3kNQ8Mz4Q3PAHj0gRJWeTonirAO9E3P4GKpu05Cjc7JE4PVXgmG16tZhOFFtMS3Fa3Fh+EBCLfKkzIviOjomp5N+a2MUBBoCC8E7NQvLrwb1vDM6HMsDc+4tcS3Fa3Fl+Ede9hzHkjEILxARodZA4aHtxvl7x+EGqMgJej4yIPXB7+14MXw4ibh2Nbw/UwMD25jD214O2fbfhJbiXOCoJae6U34KppPCDdEZirQ8lcL72CmGTMk5DQ8AGMn+iPbGr6fqOENTLu/3WoMz1pgscgqT+dEedh29JxewAuUqTdEFirWcmDvHXz8oc3RcupqeIhutxrDMwZ45IGb+b59oXOifEz3muSu6YW4QJlLQ0yDWKd+4SPv4r7dd9MZXqRutoZnQNbwZpqdbOEFsbFUCIY6zFPdy/MaAODtWj0pnUpcx99+6k20er+aNmZCJmJ4w4f4GZ6JbKO/XUKG17HAJ+eHF44nQnwsZYK3lsEhUsP1YCZ4N8QoTHTsmm3jc4/9yW14DlNjY3j9VV3cxIgZnrXAkfdfTz6slTgn+GsZnMJruB6cipyG4KnFAJ94eBOPf+DayGPsDW+k3mHdlAzPoHtu9YP7b2EMbuMoCY5zIomhlpymJ68heBGr+YsfewcP3Hubn+H1dHA0vFazg2ORMIntWIojRQeQpGWj/x+NyAs34EJKY3DVMaXuf7v4Fvbs2OJleIP/42V4xlh87iN/4juWXEjTkaTFGsdKrz18UDu1YjK0/67ZNv7uiTexo9kevJWU4RmIMLy2BZ740GV+Y8lFDed3P7kFIqZnTpxfE9cQnLQUqHnXbBt/9fG30WpEzYKI4UULGPwfI8MzXcP7zGOXaN0NOSsc50QS2bVcjP4Rv8vKueIVVQTXTvVU86H7buGvP/EWWo1ONYYXXdFxN7yInnaHseFxnRMuimkZySvipsfr1vFcOzVQ3Yfuu4V//fE/otmIT/pAhmeG/z98H2PD6+sBc8PjOCdc+JonkfN5AFfT49ipJRl03/hmm+3whjf2PmaGZ2KGF3kfO8PjugBw4V/HWvSPUdNrjj5JCo6dWlHNh+67hf/w5JvYNRv7fY0ihte/e7Ikw4Pb8AwsD8PjOCeSCKglGmIAMdMzn71Aa6XHtVMJ1Lxrto0vf+r3OHjvnW5JRQ0v8vrx9zEwvIhZTzK8VrODpx9/l67hcZ0TLsrRMpZTuG4XfzZoCdPg2qkE694128bfHP8DPnTwRjbD66/oHK8ffx9hw4uuTkfeO254FsD+3Xe61+FRhNjYyk3582Qt/sC46Vkz9qJS4NipBI3OxYnH38XnP/Kn0YAjbngmYnhgbHgmYnijZSUaXscCH33/dRx7ON/Xz4PBZHxNpUoddjynGDe9Ronn9Th2KseaATz2vuv4uyd+h7ldd8eNqm86XA3PRAwvXvvIe8cNb6bVwWceu+T+Lm0VMB1fTkjoaK/FH3GWZF9YsK7HvVB5I+SEa91xDPCLN/dhfWMOnZ4otoZnIvMqo+FZCzzywM3yfrJxElLGFkBNy0Xz5xfm4w8m/QTkWa+75vrpxbXuODEdHz+0ib994k3cv+cOP8OLnafLY3g7Z9r4zGOXqjc8CWMLoDtPrPuo1W16Ps7rUW2IaejlBB8AABWCSURBVHCt28UEHbtm2/g3i2/hqccuYdfs+DV9pAzPRAwvLi2D4Vnb/dWyp6q8HEXK+OKgo9E543rYWbL90dElWLuaa0eUGyEJjjUnkVPLS6/vx6/f3oN2x9AwvHgNBQzPWoNHD75X3cpOx1c17JjZb46vj/0URqIE+8LCVQD7Um2cU0P04VhzEh61vLSxH6+/uxtb7UY1hhfRUtTwKjU7HV9Vc878+YVF1xOtCW9aA/ClxGd5NgTfuuME0vHJ+Sv45PwV/ObtPXj1rb24cbtVjuEZOyIpr+FZADPG4rH3X68mkdXxRQNrnIe2wGTTO4O46XFtCK51uyhJy4cfvIEPP3gDl27M4ld/3Iu3rt6D7U4jUkJBwxt5vrjhWQAP7L2Dj0767YpQSBlfUnQAQNMmml7y4e3q4hyaW1cmv4owHGtOgoiWN6/sxG/f2Y3LN2ax3WmQMLy5XVt49OANHNhz15fMdBDpEy9I0tLFealKn4ly7Y8W1gEc811RMCR1HnEtt+428cpbe3H1vVlcv91Cu9NINrzYebrh89kN756Zbdx/7108cv97uqIrgiQtcQyeNU9eWE56etLhLWCwAov/4rsm70jpQEY6ds628WeHR4Ox197eg83bLbx3p4VrN2cAA7Q7Q1FpDM8CaAJoNCx2z25j5442Dt6b8OtjZcCoT6YiSYuLgT73pSpjL3NhV4/Mo9V83VdNXpHUgVK0TNGx1W5guz3+olbTYqb34+VkqEmfsGdc36Z58sLcpLckfSOju70Tr26A0i3kTeQfd6RoyaBjptnBztn22D8yhielTwA5OlxM7qeJqzxgiun1drCSsSS/SByIkrRwR2KfSNASJ7W2yYe2QBrT22pP3UgQpHSepIEoRYsUHYAsLS6yads0T75S3PRKPcSV0oFSdAAytXBHUp+4yK8v1QJt+koPACyeybz7tEjqQGk6VAsdpOhIwoe+jllJ87J0ptee8XuIK6kDJWrhjvYJD/z208X4DwAlkcr0zIn1q7B4tlBJgJwOlDipuGuRogOQpcVFEG3pVnlA2pUegDSpiBMpHShFByBTC3ck9YmL0Po62ytZSkmN/dHCBoDDfrdKHClapOgA5GiRoiOJ8vR9xzx54WTaF2dY6QETl5CSPqmkaJGiA5CpRSJV9JNJl9r2yWZ6244lpJQO1ElFD4l9IkGLi+q0XTRPXFjJ8oZMpmdOvLoBi2fFdKAUHYBMLdyR1CcuSOhLH2D0yXh4C8Bk3wk5Ku8oT5AYdJ6QokWKjiSo6csQYPTJbHrm8+fXAFzM+r7KodZZeZGiA5CpRSJ0++lZ89SrG1nflH2lBwAGp3O9r2zodlZ2pOlQLfShrs3k+6ZYbkn2H1JevlI2lDspK1K0SNEByNLigo++s+bJC0t53phvpQcAlti5PeqfSmmRtHqQpkOCFhcs9XVy3w8g/0pvdXEOM1sbSPvbuCFg1UkTkKIDUC1c4K3tonky+Yd/ppF7pdf9Pq4Jd/eVxB2D4adSAtJ0qBbaSNFWMFMoJL+01R73TooiRYsUHYAsLS6k6DMAbLFVHlDknB56q72UN+7LvnHI+FQCZGrhjqQ+cSFJX1SHhytHCjeJ/cmRebSb6/C12pPQSYAcHYBq4YIkbS4tHlZ5QMGVHgCYp17dKHxuT+qnEmck9okELXEkaZumxdP1wV6aKte5PQmd1EeKFik6AFlaXEjRl1aHp1Ue4GGlB2RIcuv0qcQJaTokaHEhRV8eHR6/BebF9AAA261nAGw6n5PQUYCcQQfI0SJFRxKS9OXXcTbr7aMm4c30eknu6eEDkNFZUnQAMrVIRGI/FdFizGk/xfQ253NjAGD/keh3crMiYcABcnQAsrS4kKLPr46z5ol837FNwt/hbR/TOeV9m2Uh8ROWO5L6xIUUfaF0tNvLnrfo3/TMZ145A+Cs7+0GQ8qgA+RokaIjCUn6wur4ep775U3D/0qvC+3VnsRBJ0mLRCT2U1gtm5iZOR1iw0FMz3z2wjqAr4fYdiF00NFDkhYXUrSV30+nzPH1qyE2HEyCXV2cw2zFt54CZAy4PlK0SNGRhBR91enwHl5ECXV4272ExXSWQ21/8s6hn7DUkKIjCUn6qtcR9PRYMNMDSg41JA46SVokIrGfqtfydfPEhfWQOwhqet09tJeR9E0NH9DoqOLQGXTFkaQljiRt1LRYXAwVXkQJbnrdyNnzHZapdVZepOgAZGlxIUUb6X7qBAsvopQmvfA3NUh2Uk6kaJGiIwlJ+uhrCRpeRAl/eNunY5Yzv4f0p1JGJGqRiMR+4qAlwDcvkijN9Mznz68B+E66F4NHR02D06CbhiQtcSRp46jFmq+F+OZFEuWt9ACg0T6Fabef4tRZLqToAGRpcSFFG+d+sriI2Vapv6pYqumNhRqcOyuONB0StLiQok+KjpLCiyiVNJn9sd5+ihRSdCQhSZ8kLSWGF1HKPbztY3KEGlQQ8wkLOTpcSOwnCVqilBheRKnE9MxTGUINCkgadJK0uJCiTXw/lRteRKlmpQcAZkKoQQUpg078BIIMfVJ0JDHUdxGtcsOLKJWZnpffyw2BlIEnRUcSkvRJ0eHC1U+m/PAiSuVNTSLUqLwVPCJJSxxJ2iRpcZGs76z5dPnhRZTqDm/7VBVqSFwpSNDiQoq2uvTTJH3b1YQXUSo3vdJDDSmDTicQD6ToSCKTvurCiyiVmx6A8KGGlIEnRUcSkvRJ0eEiXz9VGl5EIWF6QUINnUA8kNhPErS4KKKt4vAiCqnuKRxqkFJTEElaXEjRJ0VHEn70VR5eRCGx0huQJ9SQ9OkqSYsLKfqk6EjCtz4C4UUUUqaXKdSQMuh0AvFBig4XwfqJRngRhZTpAZgcaugE4oHEfpKgJU54bWTCiyjkTG8s1JA06CRpiSNJmyQtLsrSRii8iEK2W+1PCHxTwwdkW9gTUvRJ0ZFE+fpIhRdRyK30hujtp8giSZ8UHS6q7Cdi4UUUsqZnnjq/Bsvo9lOATiAuSNISh4Q2euFFFLKmByD8NzV8QGKQBUKSNklaXNDRRjK8iELa9IL8ULgPdALxoC79REkf0fAiCqXmSoREqMGipQogRZ8UHUnQ1kc2vIhCeqU3RG8/FQRJ+qTocMGlnwiHF1FYmF7poQaHAZYXLhMoDZK0uGCljXZ4EYWF6QEIH2roBOJBXfqJlz7y4UUUNqYXJNTgOcDSI0WfFB1JcNfHILyIwq6ZC4ca7BRnRJI+SVriyNHGIryIwmalNyRnqMH5k3Qa3FcKUSRpcSFNG5PwIgo708sUaugE4kFd+kmcPj7hRRR2pgdgcqghdoD1kKJPio4k5OtjFV5EYWl6Y6GG/AEmR58UHS4k9ZOLEX28wosorLvH/pTANzVCwbpnYkjSEkeyNsCtz+Cs+SSv8CIKy5XeAMv49lMuJK0UJGlxUQdtSfoa/MKLKKxNr/QfCg+FlAlUF6OTrm8S1nzNHOcXXkRhbXoAAMvg9lMuJE0gKTpcSOonF9n0sQ0vorA3vSA/FB4KSRNIkpY4krUBBfTxDS+iiOlWsqGGmBaGLC0uJOsrqo15eBGF/UpvALVQQ8pKQVc9vPGljXl4EUWM6ZEINaRMICk6klB92RAQXkQRY3oAqgk1JE0gKTpcSOonF+H0iQgvoogyvdJCDUkTSJIWF3XQFlSfjPAiisjhECzUkNJaUnQkofp87UdMeBFF1EpvgM9QQ8pKSIqOJFSffwSFF1FEml7hUEPSBJKiw4WkfnJRpT5h4UUUkaYHIHuoIWkCSdLiog7aqtUnLryIItb0Uoca1Q8wP9CYLOGQrI+cNnnhRRQyzRwKZ6ghRbUUHUmovvIRGl5EEbvSG9APNch9mhZAig4XkvrJBXV9QsOLKOJNzzx1fg1G0O2nqE6WotRBG3V9gsOLKOJNDwDQ0dtPkUSyPn7aRIcXUWphekF+KDwU/CZLNuqijx2yw4soLLsnL/ZForefAmT3hGRtAH99NQgvotRipTegQ/T2U9wnjQvJ2gBZ+moQXkSplenp7adKoA7aJOmrSXgRpVamB6CaUEPiZIlSF33yqE14EaV2pldqqCF3stTH6CTqG+iqT3gRRWKXpiJYqCG5RSVrA+qmr1bhRZTarfQG+Aw1JK8KgHpoq5u+moUXUWprenr7qSnURZ9EpvZd/cKLKLU1PQDZQ426GIHq40d6bRfRqF94EaXWppc61JA6UQDZRgDUR19abD3DiyhSh0ImnKGG9JaRrE+yNqCIvtqGF1FqvdIb0BF4+ykXkvVJ1gb40Vfj8CKKmh6IfFMjFHUxA4l47bt6hxdR1PT6cL39lIu6GJ10ff6ofXgRRU2vR2k/FB6SOhiB6suOhhcjSB1CubEvLmzAEL39lAvJPShZG1CWPg0vYuhKL06D2O2nXNRl1SORsvtOw4sx1PRimE+fX4MlGGrUxeik6yt3pxpeOFDTc0El1KiLEai+EGh4kYCanoPKQw01Ar5Q0afhRSJVdw1pSg01pPeEZH30tGl4MQFd6U0idKhBZVUQirroo4aGFxNR05tAkFCjLkag+ipCw4tpqOlNw1eoQXqiFIS8ERSEjz4NL1KgpjeFQqEGn8mSjzpo46RPw4tUcOrSSkkdakhvUcn6eGvT8CIlutJLy6RQg+OqIAt10ccZDS9So6aXEmeoIWGyJFEXoxOhT8OLLKjpZaHTPgWDTTmTxUEdtMnSp+FFRtT0MlDqD4WXiUwz6CJZGwA0NLzIitShEBT7s0A/FF4m0ntesr6htrPmzzS8yIqu9HLB4PZTLqSveuqib/C3hhd5UNPLgfk0o9/UqIsR1E2f1fAiL2p6edkmcvupJOpoBFKYrk/DiwKo6eWEZKhRFzOQSJa+MxpeFEHqECqNykMN6T0oWV8+bRpeFERXeoWpINSoy4pOur5c79XwoihqegUpNdSogxGovmQ0vPCCmp4PQoYadTEDifjtOw0vPKGm5wHvoUZdjE6ivlDaNLzwhsRhVxmFQg3pPaH6iqDhhUd0peeVHKGG1BUPIHtFB5SnT8MLr6jpeSR1qCHZDCRrA8rXp+GFd9T0fJMUatTFDCRSXd9peBEANT3PjIQadTE66foq27+GFyGQOlwrx/5cwO2nXEgfMXT0aXgRCF3phcIyvf2Ui7qs6Cjp0/AiGGp6gWB1+6kkqBmBTygaXR8NL4KipheSJvHbT7mgbAY+oK9Nw4vAqOkFxBwv8EPhZVIXo+OgT8OL4HAYBuwhGWpI73me+jS8KAFd6ZUBpVCDy4onD5xWdC40vCgFNb0SqDzU4G4G05CgTcOL0lDTK4uyQ426GJ0MfRpelIiaXkmUEmrIMoJxpOrT8KJUpA0f8gQJNST3omRtXTS8KBld6ZWNr1BD6qoHkK0tjoYXpaOmVzKFQg3pZiBZmwuj4UUVqOlVQZZQoy5GJ1Wfi67ei4CGF1WgplcBqUINyUZQX6OLaNbwoirqNOzIMRZqSO4NydqSSNZ81hzX8KIqdKVXJdYsi1/1SNbmIlV/anhRJWp6FWI+fX4Nlvntp1xIN3IXqfVqeFE1anpVw/H2Uy7qbHTpNWt4QQA1vYrpfuozuP2UCzW6jGh4QYE6DVfS2JcI3n4qibqNGj96Nbwggq70qNAhdPspF3Ve1XlBwwsqqOkRgWSoUWej86pZwwtKqOlRgkKooUbnGw0viKGmR4hKQw01ukBoeEGNOg1zNpQWatSt98vXq+EFQXSlR5GQoUadD19LR8MLiqjpEcR7qFFno6tMs4YXVFHTo0rRUKPySV8BdDRreEEYNT2i5A41aEz68qBjdBE0vKAMqaGijJMq1KhjL9LVrOEFcXSlR52kUIPkCicwLDRreEEdNT3ijIQaLCa9Z1hp1vCCA2p6HGi2T8EIuP1UWlgZ3QANL5igpseAUn4onAL8jC6ChhdcYDvE6oj9Z0a3n0qLjBGo4QUjdKXHCUP89lNp4Xn4OgENLzihpscIc7zAD4VXjTij66PhBTfU9LhhCNx+KgsijW6AhhcMUdNjBotQQ+yqLo6GFxwRPyylQi7UqN9I0vCCKbrS4wqFUKM2KzoXGl5wRU2PKZWGGrU1uj4aXnBGTY8zZYYatV7VRTAaXnBHTY8xwUMNNbou0XawGl5wp+7DWQReQw0dEV1c7WBw1hzT8II7utKTQNFQQ1d0Xaa1Q0fDCwmo6Qkgd6ihRpfe8K2GF1JQ05NC2lBDV3VdsrWBhheCUNMTwsRQQ42uS9520PBCFHWfBuIYhBras12KtoOGF+LQlZ40jFmuveH5XNlqeCEONT1hsL79VFF8H8JreCESNT2RMLv9VBHCna/U8EIoanoCyf1D4VwoI5jR8EIsdT/7Ixr7MrHbTxWhzJGq4YVodKUnGgK3nypKFZfaaHghGjU9wbANNaq8rlDDC/Go6YmHSahB4wJqDS9qgJqecEiHGjSMboiGF7WAynBTAkMq1KA46jS8qA260qsNFYca1FZ1cTS8qA1qejWhklCDutH10fCiVqjp1YoSQg0uRjdEw4uaoaZXI4KGGryMboiGF7WD4zBVCuIt1OA+ejS8qCW60qslBUINfoevyWh4UUvU9GpI5lBDktH10fCitqjp1ZYpoYZEoxui4UWNUdOrKYmhhlyjG6LhRa2RPryVKdiXFzZgiHxToww0vKg9utKrPQJuP5UFDS9qj5pezTHHz6/BMLz9VB40vFCgpqcAQIfJ7aeKoeGFAkBNT8GUHwqXgoYXSg8NMpQBdp3Q7ad8ouGFEkFXesoQKzTU0PBCiaCmpwwQGWpoeKHEUNNTRpEVamh4oYyhpqeMICrU0PBCcaBBhuKEfaih4YWSgK70FDfcQw0NL5QE1PQUJ6xDDQ0vlAmo6SnJ8Aw1NLxQJqKmpyTCMtTQ8EKZggYZylTYhBoaXigp0JWeMh0uoYaGF0oK1PSUqbAINTS8UFKipqekg3aooeGFkho1PSUVpEMNDS+UDGiQoWSCXKih4YWSEV3pKdmgFmpoeKFkRE1PyQSpUEPDCyUHanpKdmiEGhpeKLlQ01MyQyLU0PBCyYkGGUpuKgs1NLxQCqArPSU/VYUaGl4oBVDTU3JTSaih4YVSEDU9pRjlhhoaXiiFUdNTCtENNXCqlJ1Zs6zhhVIUNT2lMOb4hRUYPBt0JxZfNcfPrwXdh1ILNL1VvGHPLazA4iv+N4yvmuMXVrxvV6klutJTvGGOXViGxVfh7xzfJmzny2p4ik/U9BSvmOMXVmDbizA4W2xDeBZ2Zt4cf+WMp9IUBYAe3ioBsS8fXULDnoLFl1K+ZRMGZ9Bpn9bLUpRQqOkpwbEvL84Bd5aA5iIadhHAXOTpq+iYdQBrGlQoZfD/AbwpstA5CfRQAAAAAElFTkSuQmCC",
+      "e": 1
+    }
+  ],
+  "layers": [
+    {
+      "ddd": 0,
+      "ind": 2,
+      "ty": 2,
+      "nm": "Location",
+      "refId": "image_0",
+      "sr": 1,
+      "ks": {
+        "o": { "a": 0, "k": 100, "ix": 11 },
+        "r": { "a": 0, "k": 0, "ix": 10 },
+        "p": { "a": 0, "k": [541.309, 544.456, 0], "ix": 2 },
+        "a": { "a": 0, "k": [158.5, 451, 0], "ix": 1 },
+        "s": {
+          "a": 1,
+          "k": [
+            {
+              "i": { "x": [0.39, 0.39, 0.39], "y": [1, 1, 1] },
+              "o": { "x": [0.61, 0.61, 0.61], "y": [0, 0, 0] },
+              "t": 160,
+              "s": [100, 100, 100]
+            },
+            {
+              "i": { "x": [0.39, 0.39, 0.39], "y": [1, 1, 1] },
+              "o": { "x": [0.61, 0.61, 0.61], "y": [0, 0, 0] },
+              "t": 170,
+              "s": [87, 100, 100]
+            },
+            {
+              "i": { "x": [0.39, 0.39, 0.39], "y": [1, 1, 1] },
+              "o": { "x": [0.61, 0.61, 0.61], "y": [0, 0, 0] },
+              "t": 180,
+              "s": [100, 77, 100]
+            },
+            {
+              "i": { "x": [0.39, 0.39, 0.39], "y": [1, 1, 1] },
+              "o": { "x": [0.61, 0.61, 0.61], "y": [0, 0, 0] },
+              "t": 190,
+              "s": [100, 103, 100]
+            },
+            {
+              "i": { "x": [0.833, 0.833, 0.833], "y": [1, 1, 1] },
+              "o": { "x": [0.167, 0.167, 0.167], "y": [0, 0, 0] },
+              "t": 200,
+              "s": [100, 100, 100]
+            },
+            {
+              "i": { "x": [0.39, 0.39, 0.39], "y": [1, 1, 1] },
+              "o": { "x": [0.61, 0.61, 0.61], "y": [0, 0, 0] },
+              "t": 289,
+              "s": [100, 100, 100]
+            },
+            {
+              "i": { "x": [0.39, 0.39, 0.39], "y": [1, 1, 1] },
+              "o": { "x": [0.61, 0.61, 0.61], "y": [0, 0, 0] },
+              "t": 299,
+              "s": [87, 100, 100]
+            },
+            {
+              "i": { "x": [0.39, 0.39, 0.39], "y": [1, 1, 1] },
+              "o": { "x": [0.61, 0.61, 0.61], "y": [0, 0, 0] },
+              "t": 309,
+              "s": [100, 77, 100]
+            },
+            {
+              "i": { "x": [0.39, 0.39, 0.39], "y": [1, 1, 1] },
+              "o": { "x": [0.61, 0.61, 0.61], "y": [0, 0, 0] },
+              "t": 319,
+              "s": [100, 103, 100]
+            },
+            { "t": 329, "s": [100, 100, 100] }
+          ],
+          "ix": 6
+        }
+      },
+      "ao": 0,
+      "ip": 0,
+      "op": 14100,
+      "st": 0,
+      "bm": 0
+    },
+    {
+      "ddd": 0,
+      "ind": 3,
+      "ty": 4,
+      "nm": "Shape Layer 5",
+      "sr": 1,
+      "ks": {
+        "o": { "a": 0, "k": 100, "ix": 11 },
+        "r": { "a": 0, "k": 0, "ix": 10 },
+        "p": { "a": 0, "k": [586, 493, 0], "ix": 2 },
+        "a": { "a": 0, "k": [46, -47, 0], "ix": 1 },
+        "s": { "a": 0, "k": [100, 100, 100], "ix": 6 }
+      },
+      "ao": 0,
+      "ef": [
+        {
+          "ty": 28,
+          "nm": "Set Matte",
+          "np": 8,
+          "mn": "ADBE Set Matte3",
+          "ix": 1,
+          "en": 1,
+          "ef": [
+            {
+              "ty": 10,
+              "nm": "Take Matte From Layer",
+              "mn": "ADBE Set Matte3-0001",
+              "ix": 1,
+              "v": { "a": 0, "k": 10, "ix": 1 }
+            },
+            {
+              "ty": 7,
+              "nm": "Use For Matte",
+              "mn": "ADBE Set Matte3-0002",
+              "ix": 2,
+              "v": { "a": 0, "k": 4, "ix": 2 }
+            },
+            {
+              "ty": 7,
+              "nm": "Invert Matte",
+              "mn": "ADBE Set Matte3-0003",
+              "ix": 3,
+              "v": { "a": 0, "k": 0, "ix": 3 }
+            },
+            {
+              "ty": 7,
+              "nm": "If Layer Sizes Differ",
+              "mn": "ADBE Set Matte3-0004",
+              "ix": 4,
+              "v": { "a": 0, "k": 1, "ix": 4 }
+            },
+            {
+              "ty": 7,
+              "nm": "Composite Matte with Original",
+              "mn": "ADBE Set Matte3-0005",
+              "ix": 5,
+              "v": { "a": 0, "k": 1, "ix": 5 }
+            },
+            {
+              "ty": 7,
+              "nm": "Premultiply Matte Layer",
+              "mn": "ADBE Set Matte3-0006",
+              "ix": 6,
+              "v": { "a": 0, "k": 1, "ix": 6 }
+            }
+          ]
+        }
+      ],
+      "shapes": [
+        {
+          "ty": "gr",
+          "it": [
+            {
+              "ind": 0,
+              "ty": "sh",
+              "ix": 1,
+              "ks": {
+                "a": 0,
+                "k": {
+                  "i": [
+                    [0, 0],
+                    [0, 0]
+                  ],
+                  "o": [
+                    [0, 0],
+                    [0, 0]
+                  ],
+                  "v": [
+                    [-166, -432],
+                    [434, 162]
+                  ],
+                  "c": false
+                },
+                "ix": 2
+              },
+              "nm": "Path 1",
+              "mn": "ADBE Vector Shape - Group",
+              "hd": false
+            },
+            {
+              "ty": "st",
+              "c": { "a": 0, "k": [1, 1, 1, 1], "ix": 3 },
+              "o": { "a": 0, "k": 100, "ix": 4 },
+              "w": { "a": 0, "k": 30, "ix": 5 },
+              "lc": 1,
+              "lj": 1,
+              "ml": 4,
+              "bm": 0,
+              "nm": "Stroke 1",
+              "mn": "ADBE Vector Graphic - Stroke",
+              "hd": false
+            },
+            {
+              "ty": "tr",
+              "p": { "a": 0, "k": [0, 0], "ix": 2 },
+              "a": { "a": 0, "k": [0, 0], "ix": 1 },
+              "s": { "a": 0, "k": [100, 100], "ix": 3 },
+              "r": { "a": 0, "k": 0, "ix": 6 },
+              "o": { "a": 0, "k": 100, "ix": 7 },
+              "sk": { "a": 0, "k": 0, "ix": 4 },
+              "sa": { "a": 0, "k": 0, "ix": 5 },
+              "nm": "Transform"
+            }
+          ],
+          "nm": "Shape 2",
+          "np": 3,
+          "cix": 2,
+          "bm": 0,
+          "ix": 1,
+          "mn": "ADBE Vector Group",
+          "hd": false
+        },
+        {
+          "ty": "gr",
+          "it": [
+            {
+              "ind": 0,
+              "ty": "sh",
+              "ix": 1,
+              "ks": {
+                "a": 0,
+                "k": {
+                  "i": [
+                    [0, 0],
+                    [0, 0]
+                  ],
+                  "o": [
+                    [0, 0],
+                    [0, 0]
+                  ],
+                  "v": [
+                    [-254, -344],
+                    [346, 250]
+                  ],
+                  "c": false
+                },
+                "ix": 2
+              },
+              "nm": "Path 1",
+              "mn": "ADBE Vector Shape - Group",
+              "hd": false
+            },
+            {
+              "ty": "st",
+              "c": { "a": 0, "k": [1, 1, 1, 1], "ix": 3 },
+              "o": { "a": 0, "k": 100, "ix": 4 },
+              "w": { "a": 0, "k": 30, "ix": 5 },
+              "lc": 1,
+              "lj": 1,
+              "ml": 4,
+              "bm": 0,
+              "nm": "Stroke 1",
+              "mn": "ADBE Vector Graphic - Stroke",
+              "hd": false
+            },
+            {
+              "ty": "tr",
+              "p": { "a": 0, "k": [0, 0], "ix": 2 },
+              "a": { "a": 0, "k": [0, 0], "ix": 1 },
+              "s": { "a": 0, "k": [100, 100], "ix": 3 },
+              "r": { "a": 0, "k": 0, "ix": 6 },
+              "o": { "a": 0, "k": 100, "ix": 7 },
+              "sk": { "a": 0, "k": 0, "ix": 4 },
+              "sa": { "a": 0, "k": 0, "ix": 5 },
+              "nm": "Transform"
+            }
+          ],
+          "nm": "Shape 1",
+          "np": 3,
+          "cix": 2,
+          "bm": 0,
+          "ix": 2,
+          "mn": "ADBE Vector Group",
+          "hd": false
+        },
+        {
+          "ty": "tm",
+          "s": { "a": 0, "k": 0, "ix": 1 },
+          "e": {
+            "a": 1,
+            "k": [
+              {
+                "i": { "x": [0.056], "y": [1] },
+                "o": { "x": [0.736], "y": [0] },
+                "t": 200,
+                "s": [0]
+              },
+              {
+                "i": { "x": [0.056], "y": [1] },
+                "o": { "x": [0.167], "y": [0] },
+                "t": 220,
+                "s": [100]
+              },
+              {
+                "i": { "x": [0.264], "y": [1] },
+                "o": { "x": [0.944], "y": [0] },
+                "t": 350,
+                "s": [100]
+              },
+              { "t": 370, "s": [0] }
+            ],
+            "ix": 2
+          },
+          "o": { "a": 0, "k": 0, "ix": 3 },
+          "m": 1,
+          "ix": 3,
+          "nm": "Trim Paths 1",
+          "mn": "ADBE Vector Filter - Trim",
+          "hd": false
+        }
+      ],
+      "ip": 0,
+      "op": 14100,
+      "st": 0,
+      "bm": 0
+    },
+    {
+      "ddd": 0,
+      "ind": 4,
+      "ty": 4,
+      "nm": "Shape Layer 4",
+      "sr": 1,
+      "ks": {
+        "o": { "a": 0, "k": 100, "ix": 11 },
+        "r": { "a": 0, "k": 0, "ix": 10 },
+        "p": { "a": 0, "k": [673, 685, 0], "ix": 2 },
+        "a": { "a": 0, "k": [133, 145, 0], "ix": 1 },
+        "s": { "a": 0, "k": [100, 100, 100], "ix": 6 }
+      },
+      "ao": 0,
+      "ef": [
+        {
+          "ty": 28,
+          "nm": "Set Matte",
+          "np": 8,
+          "mn": "ADBE Set Matte3",
+          "ix": 1,
+          "en": 1,
+          "ef": [
+            {
+              "ty": 10,
+              "nm": "Take Matte From Layer",
+              "mn": "ADBE Set Matte3-0001",
+              "ix": 1,
+              "v": { "a": 0, "k": 10, "ix": 1 }
+            },
+            {
+              "ty": 7,
+              "nm": "Use For Matte",
+              "mn": "ADBE Set Matte3-0002",
+              "ix": 2,
+              "v": { "a": 0, "k": 4, "ix": 2 }
+            },
+            {
+              "ty": 7,
+              "nm": "Invert Matte",
+              "mn": "ADBE Set Matte3-0003",
+              "ix": 3,
+              "v": { "a": 0, "k": 0, "ix": 3 }
+            },
+            {
+              "ty": 7,
+              "nm": "If Layer Sizes Differ",
+              "mn": "ADBE Set Matte3-0004",
+              "ix": 4,
+              "v": { "a": 0, "k": 1, "ix": 4 }
+            },
+            {
+              "ty": 7,
+              "nm": "Composite Matte with Original",
+              "mn": "ADBE Set Matte3-0005",
+              "ix": 5,
+              "v": { "a": 0, "k": 1, "ix": 5 }
+            },
+            {
+              "ty": 7,
+              "nm": "Premultiply Matte Layer",
+              "mn": "ADBE Set Matte3-0006",
+              "ix": 6,
+              "v": { "a": 0, "k": 1, "ix": 6 }
+            }
+          ]
+        }
+      ],
+      "shapes": [
+        {
+          "ty": "gr",
+          "it": [
+            {
+              "ind": 0,
+              "ty": "sh",
+              "ix": 1,
+              "ks": {
+                "a": 0,
+                "k": {
+                  "i": [
+                    [0, 0],
+                    [0, 0]
+                  ],
+                  "o": [
+                    [0, 0],
+                    [0, 0]
+                  ],
+                  "v": [
+                    [-162, 438],
+                    [428, -148]
+                  ],
+                  "c": false
+                },
+                "ix": 2
+              },
+              "nm": "Path 1",
+              "mn": "ADBE Vector Shape - Group",
+              "hd": false
+            },
+            {
+              "ty": "st",
+              "c": { "a": 0, "k": [1, 1, 1, 1], "ix": 3 },
+              "o": { "a": 0, "k": 100, "ix": 4 },
+              "w": { "a": 0, "k": 30, "ix": 5 },
+              "lc": 1,
+              "lj": 1,
+              "ml": 4,
+              "bm": 0,
+              "nm": "Stroke 1",
+              "mn": "ADBE Vector Graphic - Stroke",
+              "hd": false
+            },
+            {
+              "ty": "tr",
+              "p": { "a": 0, "k": [0, 0], "ix": 2 },
+              "a": { "a": 0, "k": [0, 0], "ix": 1 },
+              "s": { "a": 0, "k": [100, 100], "ix": 3 },
+              "r": { "a": 0, "k": 0, "ix": 6 },
+              "o": { "a": 0, "k": 100, "ix": 7 },
+              "sk": { "a": 0, "k": 0, "ix": 4 },
+              "sa": { "a": 0, "k": 0, "ix": 5 },
+              "nm": "Transform"
+            }
+          ],
+          "nm": "Shape 1",
+          "np": 3,
+          "cix": 2,
+          "bm": 0,
+          "ix": 1,
+          "mn": "ADBE Vector Group",
+          "hd": false
+        },
+        {
+          "ty": "tm",
+          "s": { "a": 0, "k": 0, "ix": 1 },
+          "e": {
+            "a": 1,
+            "k": [
+              {
+                "i": { "x": [0.056], "y": [1] },
+                "o": { "x": [0.736], "y": [0] },
+                "t": 180,
+                "s": [0]
+              },
+              {
+                "i": { "x": [0.056], "y": [1] },
+                "o": { "x": [0.167], "y": [0] },
+                "t": 200,
+                "s": [100]
+              },
+              {
+                "i": { "x": [0.264], "y": [1] },
+                "o": { "x": [0.944], "y": [0] },
+                "t": 330,
+                "s": [100]
+              },
+              { "t": 350, "s": [0] }
+            ],
+            "ix": 2
+          },
+          "o": { "a": 0, "k": 0, "ix": 3 },
+          "m": 1,
+          "ix": 2,
+          "nm": "Trim Paths 1",
+          "mn": "ADBE Vector Filter - Trim",
+          "hd": false
+        }
+      ],
+      "ip": 0,
+      "op": 14100,
+      "st": 0,
+      "bm": 0
+    },
+    {
+      "ddd": 0,
+      "ind": 5,
+      "ty": 4,
+      "nm": "Shape Layer 3",
+      "sr": 1,
+      "ks": {
+        "o": { "a": 0, "k": 100, "ix": 11 },
+        "r": { "a": 0, "k": 0, "ix": 10 },
+        "p": { "a": 0, "k": [540, 540, 0], "ix": 2 },
+        "a": { "a": 0, "k": [0, 0, 0], "ix": 1 },
+        "s": { "a": 0, "k": [100, 100, 100], "ix": 6 }
+      },
+      "ao": 0,
+      "ef": [
+        {
+          "ty": 28,
+          "nm": "Set Matte",
+          "np": 8,
+          "mn": "ADBE Set Matte3",
+          "ix": 1,
+          "en": 1,
+          "ef": [
+            {
+              "ty": 10,
+              "nm": "Take Matte From Layer",
+              "mn": "ADBE Set Matte3-0001",
+              "ix": 1,
+              "v": { "a": 0, "k": 10, "ix": 1 }
+            },
+            {
+              "ty": 7,
+              "nm": "Use For Matte",
+              "mn": "ADBE Set Matte3-0002",
+              "ix": 2,
+              "v": { "a": 0, "k": 4, "ix": 2 }
+            },
+            {
+              "ty": 7,
+              "nm": "Invert Matte",
+              "mn": "ADBE Set Matte3-0003",
+              "ix": 3,
+              "v": { "a": 0, "k": 0, "ix": 3 }
+            },
+            {
+              "ty": 7,
+              "nm": "If Layer Sizes Differ",
+              "mn": "ADBE Set Matte3-0004",
+              "ix": 4,
+              "v": { "a": 0, "k": 1, "ix": 4 }
+            },
+            {
+              "ty": 7,
+              "nm": "Composite Matte with Original",
+              "mn": "ADBE Set Matte3-0005",
+              "ix": 5,
+              "v": { "a": 0, "k": 1, "ix": 5 }
+            },
+            {
+              "ty": 7,
+              "nm": "Premultiply Matte Layer",
+              "mn": "ADBE Set Matte3-0006",
+              "ix": 6,
+              "v": { "a": 0, "k": 1, "ix": 6 }
+            }
+          ]
+        }
+      ],
+      "shapes": [
+        {
+          "ty": "gr",
+          "it": [
+            {
+              "ind": 0,
+              "ty": "sh",
+              "ix": 1,
+              "ks": {
+                "a": 0,
+                "k": {
+                  "i": [
+                    [0, 0],
+                    [0, 0],
+                    [-118, 106],
+                    [0, 0]
+                  ],
+                  "o": [
+                    [0, 0],
+                    [0, 0],
+                    [118, -106],
+                    [0, 0]
+                  ],
+                  "v": [
+                    [-386, -194],
+                    [-148, 44],
+                    [60, 34],
+                    [348, -248]
+                  ],
+                  "c": false
+                },
+                "ix": 2
+              },
+              "nm": "Path 1",
+              "mn": "ADBE Vector Shape - Group",
+              "hd": false
+            },
+            {
+              "ty": "st",
+              "c": {
+                "a": 0,
+                "k": [0.835294177485, 0.84313731474, 0.85882358925, 1],
+                "ix": 3
+              },
+              "o": { "a": 0, "k": 100, "ix": 4 },
+              "w": { "a": 0, "k": 30, "ix": 5 },
+              "lc": 1,
+              "lj": 1,
+              "ml": 4,
+              "bm": 0,
+              "nm": "Stroke 1",
+              "mn": "ADBE Vector Graphic - Stroke",
+              "hd": false
+            },
+            {
+              "ty": "tr",
+              "p": { "a": 0, "k": [0, 0], "ix": 2 },
+              "a": { "a": 0, "k": [0, 0], "ix": 1 },
+              "s": { "a": 0, "k": [100, 100], "ix": 3 },
+              "r": { "a": 0, "k": 0, "ix": 6 },
+              "o": { "a": 0, "k": 100, "ix": 7 },
+              "sk": { "a": 0, "k": 0, "ix": 4 },
+              "sa": { "a": 0, "k": 0, "ix": 5 },
+              "nm": "Transform"
+            }
+          ],
+          "nm": "Shape 1",
+          "np": 3,
+          "cix": 2,
+          "bm": 0,
+          "ix": 1,
+          "mn": "ADBE Vector Group",
+          "hd": false
+        },
+        {
+          "ty": "tm",
+          "s": { "a": 0, "k": 0, "ix": 1 },
+          "e": {
+            "a": 1,
+            "k": [
+              {
+                "i": { "x": [0.056], "y": [1] },
+                "o": { "x": [0.736], "y": [0] },
+                "t": 160,
+                "s": [0]
+              },
+              {
+                "i": { "x": [0.056], "y": [1] },
+                "o": { "x": [0.333], "y": [0] },
+                "t": 180,
+                "s": [100]
+              },
+              {
+                "i": { "x": [0.264], "y": [1] },
+                "o": { "x": [0.944], "y": [0] },
+                "t": 310,
+                "s": [100]
+              },
+              { "t": 330, "s": [0] }
+            ],
+            "ix": 2
+          },
+          "o": { "a": 0, "k": 0, "ix": 3 },
+          "m": 1,
+          "ix": 2,
+          "nm": "Trim Paths 1",
+          "mn": "ADBE Vector Filter - Trim",
+          "hd": false
+        }
+      ],
+      "ip": 0,
+      "op": 14100,
+      "st": 0,
+      "bm": 0
+    },
+    {
+      "ddd": 0,
+      "ind": 6,
+      "ty": 4,
+      "nm": "Shape Layer 2",
+      "sr": 1,
+      "ks": {
+        "o": { "a": 0, "k": 100, "ix": 11 },
+        "r": { "a": 0, "k": -90.198, "ix": 10 },
+        "p": { "a": 0, "k": [458, 513, 0], "ix": 2 },
+        "a": { "a": 0, "k": [-188, 185, 0], "ix": 1 },
+        "s": { "a": 0, "k": [100, 100, 100], "ix": 6 }
+      },
+      "ao": 0,
+      "ef": [
+        {
+          "ty": 28,
+          "nm": "Set Matte",
+          "np": 8,
+          "mn": "ADBE Set Matte3",
+          "ix": 1,
+          "en": 1,
+          "ef": [
+            {
+              "ty": 10,
+              "nm": "Take Matte From Layer",
+              "mn": "ADBE Set Matte3-0001",
+              "ix": 1,
+              "v": { "a": 0, "k": 10, "ix": 1 }
+            },
+            {
+              "ty": 7,
+              "nm": "Use For Matte",
+              "mn": "ADBE Set Matte3-0002",
+              "ix": 2,
+              "v": { "a": 0, "k": 4, "ix": 2 }
+            },
+            {
+              "ty": 7,
+              "nm": "Invert Matte",
+              "mn": "ADBE Set Matte3-0003",
+              "ix": 3,
+              "v": { "a": 0, "k": 0, "ix": 3 }
+            },
+            {
+              "ty": 7,
+              "nm": "If Layer Sizes Differ",
+              "mn": "ADBE Set Matte3-0004",
+              "ix": 4,
+              "v": { "a": 0, "k": 1, "ix": 4 }
+            },
+            {
+              "ty": 7,
+              "nm": "Composite Matte with Original",
+              "mn": "ADBE Set Matte3-0005",
+              "ix": 5,
+              "v": { "a": 0, "k": 1, "ix": 5 }
+            },
+            {
+              "ty": 7,
+              "nm": "Premultiply Matte Layer",
+              "mn": "ADBE Set Matte3-0006",
+              "ix": 6,
+              "v": { "a": 0, "k": 1, "ix": 6 }
+            }
+          ]
+        }
+      ],
+      "shapes": [
+        {
+          "ty": "gr",
+          "it": [
+            {
+              "ind": 0,
+              "ty": "sh",
+              "ix": 1,
+              "ks": {
+                "a": 0,
+                "k": {
+                  "i": [
+                    [0, 0],
+                    [0, 0]
+                  ],
+                  "o": [
+                    [0, 0],
+                    [0, 0]
+                  ],
+                  "v": [
+                    [-472.01, -101.983],
+                    [135.878, 510.121]
+                  ],
+                  "c": false
+                },
+                "ix": 2
+              },
+              "nm": "Path 1",
+              "mn": "ADBE Vector Shape - Group",
+              "hd": false
+            },
+            {
+              "ty": "st",
+              "c": {
+                "a": 0,
+                "k": [0.835294177485, 0.84313731474, 0.85882358925, 1],
+                "ix": 3
+              },
+              "o": { "a": 0, "k": 100, "ix": 4 },
+              "w": { "a": 0, "k": 30, "ix": 5 },
+              "lc": 1,
+              "lj": 1,
+              "ml": 4,
+              "bm": 0,
+              "nm": "Stroke 1",
+              "mn": "ADBE Vector Graphic - Stroke",
+              "hd": false
+            },
+            {
+              "ty": "tr",
+              "p": { "a": 0, "k": [0, 0], "ix": 2 },
+              "a": { "a": 0, "k": [0, 0], "ix": 1 },
+              "s": { "a": 0, "k": [100, 100], "ix": 3 },
+              "r": { "a": 0, "k": 0, "ix": 6 },
+              "o": { "a": 0, "k": 100, "ix": 7 },
+              "sk": { "a": 0, "k": 0, "ix": 4 },
+              "sa": { "a": 0, "k": 0, "ix": 5 },
+              "nm": "Transform"
+            }
+          ],
+          "nm": "Shape 1",
+          "np": 3,
+          "cix": 2,
+          "bm": 0,
+          "ix": 1,
+          "mn": "ADBE Vector Group",
+          "hd": false
+        },
+        {
+          "ty": "tm",
+          "s": { "a": 0, "k": 0, "ix": 1 },
+          "e": {
+            "a": 1,
+            "k": [
+              {
+                "i": { "x": [0.056], "y": [1] },
+                "o": { "x": [0.736], "y": [0] },
+                "t": 140,
+                "s": [0]
+              },
+              {
+                "i": { "x": [0.056], "y": [1] },
+                "o": { "x": [0.333], "y": [0] },
+                "t": 160,
+                "s": [100]
+              },
+              {
+                "i": { "x": [0.264], "y": [1] },
+                "o": { "x": [0.944], "y": [0] },
+                "t": 290,
+                "s": [100]
+              },
+              { "t": 310, "s": [0] }
+            ],
+            "ix": 2
+          },
+          "o": { "a": 0, "k": 0, "ix": 3 },
+          "m": 1,
+          "ix": 2,
+          "nm": "Trim Paths 1",
+          "mn": "ADBE Vector Filter - Trim",
+          "hd": false
+        }
+      ],
+      "ip": 0,
+      "op": 14100,
+      "st": 0,
+      "bm": 0
+    },
+    {
+      "ddd": 0,
+      "ind": 7,
+      "ty": 4,
+      "nm": "Shape Layer 1",
+      "sr": 1,
+      "ks": {
+        "o": { "a": 0, "k": 100, "ix": 11 },
+        "r": { "a": 0, "k": 0, "ix": 10 },
+        "p": { "a": 0, "k": [540, 540, 0], "ix": 2 },
+        "a": { "a": 0, "k": [0, 0, 0], "ix": 1 },
+        "s": { "a": 0, "k": [100, 100, 100], "ix": 6 }
+      },
+      "ao": 0,
+      "ef": [
+        {
+          "ty": 28,
+          "nm": "Set Matte",
+          "np": 8,
+          "mn": "ADBE Set Matte3",
+          "ix": 1,
+          "en": 1,
+          "ef": [
+            {
+              "ty": 10,
+              "nm": "Take Matte From Layer",
+              "mn": "ADBE Set Matte3-0001",
+              "ix": 1,
+              "v": { "a": 0, "k": 10, "ix": 1 }
+            },
+            {
+              "ty": 7,
+              "nm": "Use For Matte",
+              "mn": "ADBE Set Matte3-0002",
+              "ix": 2,
+              "v": { "a": 0, "k": 4, "ix": 2 }
+            },
+            {
+              "ty": 7,
+              "nm": "Invert Matte",
+              "mn": "ADBE Set Matte3-0003",
+              "ix": 3,
+              "v": { "a": 0, "k": 0, "ix": 3 }
+            },
+            {
+              "ty": 7,
+              "nm": "If Layer Sizes Differ",
+              "mn": "ADBE Set Matte3-0004",
+              "ix": 4,
+              "v": { "a": 0, "k": 1, "ix": 4 }
+            },
+            {
+              "ty": 7,
+              "nm": "Composite Matte with Original",
+              "mn": "ADBE Set Matte3-0005",
+              "ix": 5,
+              "v": { "a": 0, "k": 1, "ix": 5 }
+            },
+            {
+              "ty": 7,
+              "nm": "Premultiply Matte Layer",
+              "mn": "ADBE Set Matte3-0006",
+              "ix": 6,
+              "v": { "a": 0, "k": 1, "ix": 6 }
+            }
+          ]
+        }
+      ],
+      "shapes": [
+        {
+          "ty": "gr",
+          "it": [
+            {
+              "ind": 0,
+              "ty": "sh",
+              "ix": 1,
+              "ks": {
+                "a": 0,
+                "k": {
+                  "i": [
+                    [0, 0],
+                    [0, 0]
+                  ],
+                  "o": [
+                    [0, 0],
+                    [0, 0]
+                  ],
+                  "v": [
+                    [-456, -84],
+                    [80, 454]
+                  ],
+                  "c": false
+                },
+                "ix": 2
+              },
+              "nm": "Path 1",
+              "mn": "ADBE Vector Shape - Group",
+              "hd": false
+            },
+            {
+              "ty": "st",
+              "c": {
+                "a": 0,
+                "k": [0.835294177485, 0.84313731474, 0.85882358925, 1],
+                "ix": 3
+              },
+              "o": { "a": 0, "k": 100, "ix": 4 },
+              "w": { "a": 0, "k": 30, "ix": 5 },
+              "lc": 1,
+              "lj": 1,
+              "ml": 4,
+              "bm": 0,
+              "nm": "Stroke 1",
+              "mn": "ADBE Vector Graphic - Stroke",
+              "hd": false
+            },
+            {
+              "ty": "tr",
+              "p": { "a": 0, "k": [0, 0], "ix": 2 },
+              "a": { "a": 0, "k": [0, 0], "ix": 1 },
+              "s": { "a": 0, "k": [100, 100], "ix": 3 },
+              "r": { "a": 0, "k": 0, "ix": 6 },
+              "o": { "a": 0, "k": 100, "ix": 7 },
+              "sk": { "a": 0, "k": 0, "ix": 4 },
+              "sa": { "a": 0, "k": 0, "ix": 5 },
+              "nm": "Transform"
+            }
+          ],
+          "nm": "Shape 1",
+          "np": 3,
+          "cix": 2,
+          "bm": 0,
+          "ix": 1,
+          "mn": "ADBE Vector Group",
+          "hd": false
+        },
+        {
+          "ty": "tm",
+          "s": { "a": 0, "k": 0, "ix": 1 },
+          "e": {
+            "a": 1,
+            "k": [
+              {
+                "i": { "x": [0.056], "y": [1] },
+                "o": { "x": [0.736], "y": [0] },
+                "t": 120,
+                "s": [0]
+              },
+              {
+                "i": { "x": [0.056], "y": [1] },
+                "o": { "x": [0.333], "y": [0] },
+                "t": 140,
+                "s": [100]
+              },
+              {
+                "i": { "x": [0.264], "y": [1] },
+                "o": { "x": [0.944], "y": [0] },
+                "t": 270,
+                "s": [100]
+              },
+              { "t": 290, "s": [0] }
+            ],
+            "ix": 2
+          },
+          "o": { "a": 0, "k": 0, "ix": 3 },
+          "m": 1,
+          "ix": 2,
+          "nm": "Trim Paths 1",
+          "mn": "ADBE Vector Filter - Trim",
+          "hd": false
+        }
+      ],
+      "ip": 0,
+      "op": 14100,
+      "st": 0,
+      "bm": 0
+    },
+    {
+      "ddd": 0,
+      "ind": 10,
+      "ty": 4,
+      "nm": "Bg Outlines",
+      "sr": 1,
+      "ks": {
+        "o": { "a": 0, "k": 100, "ix": 11 },
+        "r": { "a": 0, "k": 0, "ix": 10 },
+        "p": { "a": 0, "k": [539.91, 544.098, 0], "ix": 2 },
+        "a": { "a": 0, "k": [468.42, 468.42, 0], "ix": 1 },
+        "s": { "a": 0, "k": [100, 100, 100], "ix": 6 }
+      },
+      "ao": 0,
+      "shapes": [
+        {
+          "ty": "gr",
+          "it": [
+            {
+              "ind": 0,
+              "ty": "sh",
+              "ix": 1,
+              "ks": {
+                "a": 0,
+                "k": {
+                  "i": [
+                    [103.893, 103.893],
+                    [0, 0],
+                    [103.893, -103.893],
+                    [0, 0],
+                    [-103.893, -103.893],
+                    [0, 0],
+                    [-103.893, 103.893],
+                    [0, 0]
+                  ],
+                  "o": [
+                    [0, 0],
+                    [-103.893, -103.893],
+                    [0, 0],
+                    [-103.893, 103.893],
+                    [0, 0],
+                    [103.893, 103.893],
+                    [0, 0],
+                    [103.893, -103.893]
+                  ],
+                  "v": [
+                    [364.277, -188.115],
+                    [188.114, -364.277],
+                    [-188.115, -364.277],
+                    [-364.277, -188.115],
+                    [-364.277, 188.114],
+                    [-188.115, 364.277],
+                    [188.114, 364.277],
+                    [364.277, 188.114]
+                  ],
+                  "c": true
+                },
+                "ix": 2
+              },
+              "nm": "Path 1",
+              "mn": "ADBE Vector Shape - Group",
+              "hd": false
+            },
+            {
+              "ty": "fl",
+              "c": {
+                "a": 0,
+                "k": [0.952941236309, 0.956862804936, 0.956862804936, 1],
+                "ix": 4
+              },
+              "o": { "a": 0, "k": 100, "ix": 5 },
+              "r": 1,
+              "bm": 0,
+              "nm": "Fill 1",
+              "mn": "ADBE Vector Graphic - Fill",
+              "hd": false
+            },
+            {
+              "ty": "tr",
+              "p": { "a": 0, "k": [468.42, 468.42], "ix": 2 },
+              "a": { "a": 0, "k": [0, 0], "ix": 1 },
+              "s": { "a": 0, "k": [100, 100], "ix": 3 },
+              "r": { "a": 0, "k": 0, "ix": 6 },
+              "o": { "a": 0, "k": 100, "ix": 7 },
+              "sk": { "a": 0, "k": 0, "ix": 4 },
+              "sa": { "a": 0, "k": 0, "ix": 5 },
+              "nm": "Transform"
+            }
+          ],
+          "nm": "Group 1",
+          "np": 4,
+          "cix": 2,
+          "bm": 0,
+          "ix": 1,
+          "mn": "ADBE Vector Group",
+          "hd": false
+        }
+      ],
+      "ip": 0,
+      "op": 14100,
+      "st": 0,
+      "bm": 0
+    }
+  ],
+  "markers": []
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,7 @@ import SEO from '../components/seo';
 import MainMap from '../components/mainMap';
 import ResultsSidebar from '../components/resultsSidebar';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   title: {
     fontWeight: 'bold',
     fontSize: '2.25rem',
@@ -17,14 +17,25 @@ const useStyles = makeStyles({
   image: {
     margin: '0 0.5rem 1.45rem',
   },
+  // NOTE: !important styles here are necessary to override
+  // google maps inline styles
   map: {
     position: 'fixed !important',
     width: '65vw',
     height: 'calc(100% - 5.5rem)',
     top: '5.5rem',
     right: 0,
+    [theme.breakpoints.down('md')]: {
+      position: 'relative !important',
+      width: '100%',
+      height: 400,
+    },
   },
-});
+  mapLabel: {
+    textAlign: 'center',
+    width: '100%',
+  },
+}));
 
 const IndexPage = () => {
   const classes = useStyles();
@@ -33,7 +44,7 @@ const IndexPage = () => {
     <Layout>
       <SEO title="Home" />
       <ResultsSidebar />
-      <MainMap />
+      <MainMap classes={classes} />
       <div id="map" className={classes.map} />
     </Layout>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8642,6 +8642,11 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lottie-web@^5.1.3:
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.9.1.tgz#0090e575de74e49843606c1722767604e068f061"
+  integrity sha512-3uKtU6BhIK6ZRCE/QyiXq/KuRvPeEAz/VFwqd99jPbpgFY9gHLw2krqvcuCFGepeW94BipS/B3TqIfTc9pUeZg==
+
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
@@ -10938,6 +10943,14 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-lottie@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/react-lottie/-/react-lottie-1.2.3.tgz#8544b96939e088658072eea5e12d912cdaa3acc1"
+  integrity sha512-qLCERxUr8M+4mm1LU0Ruxw5Y5Fn/OmYkGfnA+JDM/dZb3oKwVAJCjwnjkj9TMHtzR2U6sMEUD3ZZ1RaHagM7kA==
+  dependencies:
+    babel-runtime "^6.26.0"
+    lottie-web "^5.1.3"
 
 react-refresh@^0.9.0:
   version "0.9.0"


### PR DESCRIPTION
In this pull request the finishing touches are added for offline support of the app (disable wifi / internet on your mobile or non-mobile device and attempt to refresh, you will see the last list of locations. 

Notably, I thought for a bit about performance, but decided to go for a map loading indicator that looks nice, though it has the shortcoming of using the [Lottie library](https://github.com/chenqingspring/react-lottie) which is convenient for smooth animation indicators but has a non-trivial bundle size (294.4k / 75.5k gzipped). If this project were released to the public and this were the only animation I would work with the design team to produce an SVG based animation that does not depend on Lottie.

In addition, a variety of states are added to cover transitive UI states for a variety of scenarios, including the following:

1. Online + Geolocation allowed
1. Online + Geolocation disallowed (shows Taos, NM as map starting point) 
1. Online + Loading (uses loading animation + text)
1. Offline 

Here are some animate GIF demos of these various scenarios:

## Initial load, grant location access

![Screen_Recording_2022-03-06_at_3 39 41_PM](https://user-images.githubusercontent.com/806536/156945233-a5112f4e-224f-4fd7-a950-66e1f57c7bbb.gif)

## Initial load, deny location access

![Screen_Recording_2022-03-06_at_3 40 23_PM](https://user-images.githubusercontent.com/806536/156945253-9c7efc69-be7b-4cf2-8dad-e40610732272.gif)

## Begin online / loaded, then disable internet connection and reload

![Screen_Recording_2022-03-06_at_2 41 46_PM](https://user-images.githubusercontent.com/806536/156943368-3dc2afa9-fc86-4f1f-b265-d78c6e4a42f3.gif)


## Initially deny, then later grant geolocation to the app

![Screen_Recording_2022-03-04_at_8 56 09_PM](https://user-images.githubusercontent.com/806536/156943213-e22814f5-9051-4d97-864b-e1a3682f9b5b.gif)

