### PR TITLE
feat: Shareable favorites

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "@react-google-maps/api": "^2.7.0",
+    "copy-to-clipboard": "^3.3.1",
     "gatsby": "^3.1.2",
     "gatsby-plugin-gatsby-cloud": "^2.1.0",
     "gatsby-plugin-google-fonts": "^1.0.1",

--- a/src/context/store.tsx
+++ b/src/context/store.tsx
@@ -21,6 +21,12 @@ const isEmptyObject = (obj: any) => obj
 const StoreContext = createContext(defaultState);
 
 const StoreProvider = ({ children }: { children: ReactChildren }) => {
+  const qsFavorites = new URLSearchParams(window.location.search).getAll(
+    'place_id',
+  );
+
+  const [initialFavorites] = useState(qsFavorites ?? []);
+
   const [located, _setLocated] = useState(defaultState.located);
   const [googleService, setGoogleService] = useState(
     defaultState.googleService,
@@ -46,7 +52,15 @@ const StoreProvider = ({ children }: { children: ReactChildren }) => {
     // of service.nearbySearch is an `array` but `typeof res === 'object'`
 
     // cooerce google maps object to array
-    const objectToArray = val?.length > 0 ? val : [];
+    let objectToArray = val?.length > 0 ? val : [];
+
+    objectToArray = objectToArray.map((place) => ({
+      ...place,
+      // initially set places from url string, but also allow toggle
+      ...(initialFavorites.includes(place?.place_id)
+        ? { favorite: place?.favorite === undefined ? true : place?.favorite }
+        : {}),
+    }));
     reactLocalStorage.setObject('at_lunch_places', objectToArray);
     _setPlaces(objectToArray);
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,6 +1579,17 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/lab@^4.0.0-alpha.60":
+  version "4.0.0-alpha.60"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz#5ad203aed5a8569b0f1753945a21a05efa2234d2"
+  integrity sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+
 "@material-ui/styles@^4.11.3":
   version "4.11.3"
   resolved "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.3.tgz"
@@ -3916,6 +3927,13 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+copy-to-clipboard@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
 
 copyfiles@^2.3.0:
   version "2.4.1"
@@ -12657,6 +12675,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Add a "share" button that shares currently selected favorites to a URL so that other users can pass along to narrow down where to go eat.

This seemed like a nice opportunistic feature that only took 20 min or so to create and would help usability since coworkers could pass along an iteratively modified shareable URL to narrow down the options until one is chosen.

Here's a demo of the following user flow

1. Visit in default state, no favorites
2. Select favorites
3. Click "share"
4. Open new window, paste copied link

![Screen_Recording_2022-03-08_at_12 15 47_PM](https://user-images.githubusercontent.com/806536/157309742-a9baacca-b656-454e-b550-fc3c6ce92580.gif)

