### PR TITLE
feat: Mobile styles finalized

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
     "no-unused-vars": 0,
     "@typescript-eslint/no-unused-vars": 2,
     "typedefs": 0,
-    "react/require-default-props": 0
+    "react/require-default-props": 0,
+    "react/jsx-one-expression-per-line": 0
   }
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,10 +9,13 @@ interface HeaderProps {
   siteTitle?: string;
 }
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   container: {
-    background: 'white',
-    marginBottom: '1.45rem',
+    padding: '1.45rem 1.0875rem',
+    margin: '0 auto',
+    [theme.breakpoints.down('md')]: {
+      padding: '3vw 3vw',
+    },
   },
   title: {
     fontWeight: 'bold',
@@ -21,13 +24,18 @@ const useStyles = makeStyles({
   },
   link: {
     textDecoration: 'none',
+    [theme.breakpoints.down('md')]: {
+      textAlign: 'center',
+      margin: '0 auto 20px',
+      display: 'block',
+    },
   },
-});
+}));
 
 function Header({ siteTitle }: HeaderProps): ReactElement {
   const classes = useStyles();
   return (
-    <Box paddingX="1.0875rem" paddingY="1.45rem" marginX="auto" marginY="0">
+    <Box className={classes.container}>
       <Typography variant="h3" component="h3" className={classes.title}>
         <Link className={classes.link} to="/">
           <img src={Logo} alt={siteTitle} />

--- a/src/components/resultsSidebar.tsx
+++ b/src/components/resultsSidebar.tsx
@@ -11,7 +11,7 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 
-import { useContext } from 'react';
+import { useContext, Fragment } from 'react';
 import { makeStyles } from '@material-ui/core';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
@@ -32,13 +32,9 @@ const useStyles = makeStyles((theme) => ({
     background: '#f2f2f2',
     padding: '1vw',
     [theme.breakpoints.down('md')]: {
-      // TODO: decide about drawer vs other hide / show for final mobile
-      // for now, we hide it
-
-      display: 'none',
-      // width: '100%',
-      // height: 'auto',
-      // position: 'relative',
+      width: '100%',
+      height: 'auto',
+      position: 'relative',
     },
   },
   contentCard: {
@@ -71,7 +67,6 @@ const useStyles = makeStyles((theme) => ({
     height: 100,
     objectFit: 'cover',
     float: 'left',
-    // paddingBottom: 16,
     marginRight: 12,
   },
   innerRow: {
@@ -112,7 +107,11 @@ export const PlaceCard = ({
   );
 
   return (
-    <div className={classes.placeContainer} style={{ width: width ?? 'auto' }}>
+    <div
+      key={place?.place_id}
+      className={classes.placeContainer}
+      style={{ width: width ?? 'auto' }}
+    >
       <img
         alt={place?.name}
         className={classes.favorite}
@@ -140,24 +139,25 @@ export const PlaceCard = ({
         </Typography>
         {place?.rating && place?.user_ratings_total && (
           <div>
-            {ratings.map((isStar) => (
-              <img alt="star" src={isStar === '+' ? StarFilled : StarEmpty} />
-            ))}
-            {' '}
-            (
-            {place?.user_ratings_total?.toLocaleString('en-US')}
-            )
+            {ratings.map((isStar, idx) => (
+              <img
+                // eslint-disable-next-line react/no-array-index-key
+                key={idx + isStar}
+                alt="star"
+                src={isStar === '+' ? StarFilled : StarEmpty}
+              />
+            ))}{' '}
+            {/* eslint-disable-next-line react/no-array-index-key */}(
+            {place?.user_ratings_total?.toLocaleString('en-US')})
           </div>
         )}
         <div className={classes.innerRow}>
           {place?.price_level ? (
             <>
-              {priceLevel.map(() => (
-                <>$</>
-              ))}
-              {' '}
-              &bull;
-              {' '}
+              {priceLevel.map((idx) => (
+                <Fragment key={idx}>$</Fragment>
+              ))}{' '}
+              &bull;{' '}
             </>
           ) : null}
           {place?.vicinity}
@@ -237,7 +237,7 @@ const ResultsSidebar = () => {
       {filteredPlaces.map((place) => (
         <Card key={place?.place_id} className={classes.card} variant="outlined">
           <CardContent className={classes.contentCard}>
-            <PlaceCard place={place} />
+            <PlaceCard key={place?.place_id} place={place} />
           </CardContent>
         </Card>
       ))}

--- a/src/components/searchBox.tsx
+++ b/src/components/searchBox.tsx
@@ -60,15 +60,12 @@ const useStyles = makeStyles((theme) => ({
     marginRight: 32,
     padding: '0 20px',
     [theme.breakpoints.down('md')]: {
-      // padding: '0',
       minWidth: '10vw',
       marginRight: 20,
     },
     [theme.breakpoints.down('sm')]: {
       fontSize: '0.8rem',
-      padding: '0 5px',
-      // width: '7vw',
-      marginRight: 3,
+      padding: '0 10px',
     },
   },
   filterPopover: {

--- a/src/components/searchBox.tsx
+++ b/src/components/searchBox.tsx
@@ -33,17 +33,43 @@ const useStyles = makeStyles((theme) => ({
   container: {
     float: 'right',
     marginTop: -7,
+    [theme.breakpoints.down('md')]: {
+      float: 'inherit',
+      margin: '0 auto',
+      paddingBottom: 20,
+      textAlign: 'center',
+      display: 'flex',
+      placeContent: 'flex-end',
+    },
+    [theme.breakpoints.down('sm')]: {
+      justifyContent: 'space-between',
+    },
   },
   searchField: {
     marginTop: 0,
     marginBottom: 0,
     float: 'right',
     minWidth: 300,
+    [theme.breakpoints.down('md')]: {
+      minWidth: '55vw',
+      width: '55vw',
+    },
   },
   filter: {
     height: 56,
     marginRight: 32,
     padding: '0 20px',
+    [theme.breakpoints.down('md')]: {
+      // padding: '0',
+      minWidth: '10vw',
+      marginRight: 20,
+    },
+    [theme.breakpoints.down('sm')]: {
+      fontSize: '0.8rem',
+      padding: '0 5px',
+      // width: '7vw',
+      marginRight: 3,
+    },
   },
   filterPopover: {
     marginTop: 12,

--- a/src/context/store.tsx
+++ b/src/context/store.tsx
@@ -2,6 +2,8 @@ import {
   createContext, useState, useEffect, ReactChildren,
 } from 'react';
 import { reactLocalStorage } from 'reactjs-localstorage';
+import { useTheme } from '@material-ui/core/styles';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 
 const defaultState = {
   located: undefined,
@@ -46,6 +48,18 @@ const StoreProvider = ({ children }: { children: ReactChildren }) => {
   const [searchSort, setSearchSort] = useState<'ascending' | 'descending'>(
     'descending',
   );
+  const [openView, setOpenView] = useState<'map' | 'list' | null>(null);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  // initially set the store with 'list' when the client loads and we know
+  // the user is at the mobile breakpoint, this defaults to `null` for the
+  // default desktop view and so we have an enum 'mobil' | 'list' | null
+  useEffect(() => {
+    if (openView === null && isMobile) {
+      setOpenView('list');
+    }
+  }, [isMobile]);
 
   const setPlaces = (val) => {
     // NOTE: google.maps.places service isn't typescript friendly here the return
@@ -124,6 +138,8 @@ const StoreProvider = ({ children }: { children: ReactChildren }) => {
         sidebarError,
         searchQuery,
         searchSort,
+        openView,
+        isMobile,
         setLocated,
         setPlaces,
         setMapRadius,
@@ -133,6 +149,7 @@ const StoreProvider = ({ children }: { children: ReactChildren }) => {
         setSearchQuery,
         setSearchSort,
         toggleFavorite,
+        setOpenView,
       }}
     >
       {children}

--- a/src/images/list-icon.svg
+++ b/src/images/list-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="17" height="16" fill="none" viewBox="0 0 17 16">
+  <path fill="#fff" d="M7 1h10v2H7zM7 7h10v2H7zM7 13h10v2H7z"/>
+  <circle cx="2" cy="2" r="2" fill="#fff"/>
+  <circle cx="2" cy="8" r="2" fill="#fff"/>
+  <circle cx="2" cy="14" r="2" fill="#fff"/>
+</svg>

--- a/src/images/map-icon.svg
+++ b/src/images/map-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="22" fill="none" viewBox="0 0 16 22">
+  <path stroke="#fff" stroke-width="2" d="M1 7.757C1 11.653 5.473 17.217 8.041 20 10.61 17.218 15 11.653 15 7.757 15 4.021 11.852 1 8.041 1 4.148 1 1 4.02 1 7.757z" clip-rule="evenodd"/>
+  <circle cx="8" cy="8" r="3" stroke="#fff" stroke-width="2"/>
+</svg>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,13 @@
+import { useContext } from 'react';
 import { makeStyles } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
 import MainMap from '../components/mainMap';
 import ResultsSidebar from '../components/resultsSidebar';
+import { StoreContext } from '../context/store';
+import ListIcon from '../images/list-icon.svg';
+import MapIcon from '../images/map-icon.svg';
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -20,20 +25,34 @@ const useStyles = makeStyles((theme) => ({
   // NOTE: !important styles here are necessary to override
   // google maps inline styles
   map: {
+    display: (props) => (props.openView === 'list' ? 'none' : 'inherit'),
     position: 'fixed !important',
     width: '65vw',
     height: 'calc(100% - 5.5rem)',
     top: '5.5rem',
     right: 0,
     [theme.breakpoints.down('md')]: {
-      position: 'relative !important',
+      position: 'fixed !important',
       width: '100%',
-      height: 400,
+      height: '100vh',
+      zIndex: '-1',
     },
+  },
+  resultsSidebar: {
+    display: (props) => (props.openView === 'map' ? 'none' : 'inherit'),
   },
   mapLabel: {
     textAlign: 'center',
     width: '100%',
+  },
+  mobileToggle: {
+    position: 'fixed',
+    bottom: 30,
+    left: 'calc(50vw - 50px)',
+    fontSize: '1.2rem',
+    width: 100,
+    fontWeight: 'bold',
+    textTransform: 'none',
   },
   // 🎉 oh the joys of integrating multiple JS systems (React + Google Maps)
   '@global': {
@@ -49,15 +68,52 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const IndexPage = () => {
-  const classes = useStyles();
+const MobileToggle = ({
+  openView,
+  setOpenView,
+  classes,
+}: {
+  openView: 'map' | 'list' | null;
+  setOpenView: (any) => any;
+  classes: object;
+}) => (
+  <Button
+    className={classes.mobileToggle}
+    onClick={() => {
+      const newView = openView === 'map' ? 'list' : 'map';
+      setOpenView(newView);
+    }}
+    variant="contained"
+    color="primary"
+  >
+    {openView === 'map' ? (
+      <>
+        <img alt="list" src={ListIcon} />
+        &nbsp;List
+      </>
+    ) : (
+      <>
+        <img alt="map" src={MapIcon} />
+        &nbsp;Map
+      </>
+    )}
+  </Button>
+);
 
+const IndexPage = () => {
+  const { openView, setOpenView } = useContext(StoreContext);
+  const classes = useStyles({ openView });
   return (
     <Layout>
       <SEO title="Home" />
-      <ResultsSidebar />
+      {(openView === 'list' || openView === null) && <ResultsSidebar />}
       <MainMap classes={classes} />
       <div id="map" className={classes.map} />
+      <MobileToggle
+        classes={classes}
+        openView={openView}
+        setOpenView={setOpenView}
+      />
     </Layout>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -101,7 +101,7 @@ const MobileToggle = ({
 );
 
 const IndexPage = () => {
-  const { openView, setOpenView } = useContext(StoreContext);
+  const { openView, setOpenView, isMobile } = useContext(StoreContext);
   const classes = useStyles({ openView });
   return (
     <Layout>
@@ -109,11 +109,13 @@ const IndexPage = () => {
       {(openView === 'list' || openView === null) && <ResultsSidebar />}
       <MainMap classes={classes} />
       <div id="map" className={classes.map} />
-      <MobileToggle
-        classes={classes}
-        openView={openView}
-        setOpenView={setOpenView}
-      />
+      {isMobile && (
+        <MobileToggle
+          classes={classes}
+          openView={openView}
+          setOpenView={setOpenView}
+        />
+      )}
     </Layout>
   );
 };


### PR DESCRIPTION
This commit finalizes the mechanism for hiding / toggling between map and list view on mobile. This was the only part where I wished for some design input about how to handle the header layout in some of the awkward transitional breakpoints. 

And then on the other hand, with the range of devices now, layouts need to be fairly fluid and adaptive without being overly opinionated about exacting margins and padding, as I feel that's a losing game with our current array of browsers to design for. 

One final note is that Alex just emailed me about having the `green` marker be indicative of active state with regard to the active marker. I liked the notion of `Double Click` events triggering the selection of a Favorite from map view on mobile (where the sidebar view isn't available), so I left it the way I had already done prior to his email response. Would be happy to change it but thought it would be nice to first show what I have (since it was already done that way) and then change it after there's a consensus from others that the path I took is not useful / suboptimal UX.

Here it is in action. This is our last commit 🎉 

![Final_Commit](https://user-images.githubusercontent.com/806536/157330455-112fc3f0-6b11-49f1-b6f8-f6b8f90574db.gif)

